### PR TITLE
Adoption d'OpenSpec : essai, corpus de specs et schéma projet francisé

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,181 @@
+---
+name: "OPSX: Apply"
+description: "Implement tasks from an OpenSpec change (Experimental)"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "artifacts", "experimental"]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+   - Optional `context`: current required project instruction input from the selected root
+   - Optional `operationGuidance`: current advisory guidance for apply
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue` (if it is not installed, run `openspec status --change "<name>" --json` to see the next artifact and `openspec instructions <artifact-id> --change "<name>" --json` for how to create it)
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   Treat `context` as a required prompt-level input. Read and consider it, and
+   apply relevant project facts, conventions, and constraints while implementing.
+   Treat `operationGuidance` as optional additive advice. Read and consider every
+   entry, and follow entries that are applicable and compatible with the built-in
+   workflow.
+
+   Keep both fields separate from CLI-returned state, missing artifacts, tasks,
+   progress, `contextFiles`, and the built-in `instruction`. They are not
+   evidence of task completion, do not replace the built-in instruction, and do
+   not permit bypassing a blocked state. If context conflicts with the built-in
+   instruction, an explicit user choice, or a CLI-controlled value, report the
+   conflict and preserve the controlling value. If guidance is inapplicable or
+   conflicts with those controlling inputs, do not follow it and explain why.
+   These are prompt-level behavior contracts, not enforceable checks.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+   Do not copy `context` or `operationGuidance` verbatim into implementation
+   files or planning artifacts unless the user separately asks for that content.
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+- Do not use context or operation guidance as proof that a task is complete
+- Apply relevant project context; report conflicts with controlling workflow inputs
+- Consider every guidance entry; explain any inapplicable or conflicting advice
+- Do not copy runtime context or operation guidance into implementation files or planning artifacts
+- Preserve CLI-controlled blocked/ready/all-done behavior and completion criteria
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,223 @@
+---
+name: "OPSX: Archive"
+description: "Archive a completed change in the experimental workflow"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "archive", "experimental"]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   When prompting, show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:archive <other>`).
+
+   **Load current archive inputs before the existing archive checks:**
+
+   After resolving the selected change and planning root, run:
+   ```bash
+   openspec instructions archive --change "<name>" --json
+   ```
+   Keep the same selected-root flags on this command. This lookup is advisory and
+   optional: it only supplies extra prompt inputs, so it must never block archiving.
+   If it exits non-zero or returns invalid JSON — for example on an older CLI that
+   does not support this command yet — continue the archive workflow with no
+   context and no operation guidance. Do not report an error and do not stop.
+
+   A successful response may omit both optional fields. Treat `context` as a
+   required prompt-level input: read and consider it, and apply relevant project
+   facts, conventions, and constraints. Treat `operationGuidance` as optional
+   additive advice: read and consider every entry, and follow entries that are
+   applicable and compatible with the built-in archive workflow.
+
+   Keep both fields separate from built-in steps, explicit user choices, resolved
+   paths, CLI checks, and command contracts. If context conflicts with one of those
+   controlling inputs, report the conflict and preserve the controlling value. If
+   guidance is inapplicable or conflicts with a controlling input, do not follow it
+   and explain why. Do not infer replacement paths, skipped prompts, or flags from
+   either field, and do not copy their text verbatim into specs, change artifacts,
+   or archive summaries unless the user separately asks for it. These are
+   prompt-level behavior contracts, not enforceable checks.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done`, `skipped`, or other)
+
+   **If any artifacts are neither `done` nor `skipped`** (skipped artifacts satisfy the requirement - the change declares skip_specs):
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON as the only
+   delta-spec source. If the `specs` entry is missing or
+   `existingOutputPaths` is empty, proceed without a sync prompt and do not infer
+   delta specs from other artifacts.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `<planningHome.root>/openspec/specs/<capability>/spec.md` (use the store-aware `planningHome.root` from step 2, not a hardcoded repo path)
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   Route on the answer:
+   - "Cancel" — stop, do not archive
+   - "Archive without syncing" or "Archive now" — proceed to archive
+   - "Sync now" or "Sync anyway" — sync, then verify (below)
+   - Anything else — ask again rather than archiving
+
+   Before a selected sync writes any main spec, run
+   `openspec instructions specs --change "<name>" --json` once with the same
+   selected-root flags. Require a zero exit status and valid artifact-instruction
+   JSON. If the lookup fails or returns invalid JSON, report the error and stop
+   before writing any main spec or moving the change. A valid response with omitted
+   `rules` is the no-rules case. Apply returned `rules` only to the content and
+   form of main specs produced by this merge; do not use them as archive guidance,
+   change CLI behavior, or copy the rule text into any output file.
+
+   Then run the `/opsx:sync` workflow inline (agent-driven intelligent merge) for change '<name>', passing the delta spec analysis and the fetched specs-rule snapshot from above, and wait for it to finish. The inline sync must reuse that snapshot without fetching `specs` instructions again. Do not delegate it to a background task — step 5 would move `changeRoot` out from under a sync that is still reading it, leaving the change archived and the main specs never updated. If your agent can only run it by delegation, delegate synchronously and wait for the result.
+
+   Then re-run the comparison from the top of this step against every capability that has a delta spec in `artifactPaths.specs.existingOutputPaths` — not only the ones the sync reports it touched. A successful sync leaves nothing left to apply, so each capability must now read as already synced:
+   - ADDED requirements present
+   - MODIFIED requirements carrying the scenario and description changes named in the delta, with their other scenarios intact
+   - REMOVED requirements gone
+   - RENAMED requirements present under the new name and absent under the old one
+
+   If the sync failed, or any capability does not match, report what differs and stop — do not archive. Nothing has moved and `changeRoot` is intact, so the user can fix the mismatch or re-run the sync and start the archive again.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate the target name: use the change name as-is when it already starts with a `YYYY-MM-DD-` prefix; otherwise prepend the current date as `YYYY-MM-DD-<change-name>`. Never stack a second date (same rule as `openspec archive`).
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/<target-name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```markdown
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```markdown
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```markdown
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```markdown
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/<target-name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Announce the selected change; prompt for selection when it is ambiguous
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, run the `/opsx:sync` workflow inline (agent-driven)
+- Never archive while a spec sync is still in flight — run the sync inline and verify the main specs before moving `changeRoot`
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting
+- Apply relevant runtime context and report conflicts; operation guidance remains advisory
+- Consider every guidance entry and explain any inapplicable or conflicting advice
+- Existing CLI checks, resolved paths, prompts, and command contracts are unchanged
+- Artifact rules constrain only the specs being written and are never operation guidance
+- Never copy runtime context, operation guidance, or artifact-rule text verbatim into output files

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,181 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "explore", "experimental", "thinking"]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+Then read the project's own context from the resolved root - `<root.path>/openspec/config.yaml` (or `config.yml`). Use the `root.path` returned above, and skip this if neither file exists:
+- `context`: project background - tech stack, conventions, constraints
+- `rules`: keyed by artifact id - the entries for an artifact apply only when you write that artifact
+
+Ground your thinking in these. They are constraints for you to follow, not content to reproduce: do NOT copy them into the conversation or into any artifact you create.
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,119 @@
+---
+name: "OPSX: Propose"
+description: "Propose a new change - create it and generate all artifacts in one step"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "artifacts", "experimental"]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with the artifacts your schema defines. With the default spec-driven schema that is:
+- proposal.md (what & why)
+- `specs/<capability>/spec.md` (what the system must do - a delta, not the main spec)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Ask the user (open-ended, no preset options):
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts, each with its `status` and its `requires` edges (the artifact IDs it directly depends on)
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create every artifact in the required set**
+
+   Use a todo list to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `skipped`/`warning`: present when the change declares skip_specs and this artifact must NOT be created - stop and pick another artifact
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context - always re-read them from disk, even if you saw them earlier in the conversation (the user may have edited them)
+      - If the `instruction` field delegates creation to a specific skill or command, invoke it to produce the artifact instead of writing the file yourself, then verify the artifact file exists at `resolvedOutputPath`
+      - Otherwise create the artifact file using `template` as the structure and write it to `resolvedOutputPath`. If `resolvedOutputPath` is a glob, follow `instruction` to choose the concrete file path
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until every artifact in the required set exists (not just `apply.requires`)**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - The required set is `applyRequires` plus every artifact reachable from those by following the `requires` edges in `status --json` - walk them transitively (spec-driven closes over proposal, specs, design, tasks). Leave artifacts outside that set alone
+      - `status` is file-existence only, so an `applyRequires` artifact reading `done` does NOT mean its dependencies exist - writing `tasks.md` early marks `tasks` done while `specs` was never written. Use each artifact's `requires` edges, not its `status`, to build the required set: a `done` artifact still lists what it depends on
+      - An artifact already reading `status: "skipped"` is satisfied: the change declares `skip_specs` in `.openspec.yaml`, so its files must NOT exist. Never try to create one
+      - Create every artifact in the required set that is missing, then re-check - creating one can unblock others
+      - Skip one only when `status` already reports it `skipped`, or when its own `instruction` says it is conditional: run `openspec instructions <artifact-id> --change "<name>" --json` and skip only if its `instruction` field marks it optional (e.g. "create only if..."). Spec-driven's `design.md` qualifies; `specs` qualifies only via the `skipped` status above, never by your own judgment. Tell the user, and do not reconsider it
+      - Dependencies are enablers, not gates: if a required artifact is still `blocked` only because you skipped a conditional dependency, write it anyway
+      - Stop when every artifact in the required set is `done`, `skipped`, or was deliberately skipped
+
+   c. **If an artifact requires user input** (unclear context):
+      - Ask the user to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions, plus any conditional artifact you skipped and why
+- What's ready: "All artifacts needed for implementation are ready."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type - it is the authoritative guidance, even for familiar artifact names
+- If the `instruction` field directs you to use a specific skill or command to create the artifact, invoke it instead of writing the artifact directly
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create every artifact the apply phase transitively depends on, not just the ids listed in `apply.requires`
+- Always read dependency artifacts before creating a new one - re-read from disk, not from conversation memory (files may have changed since you last saw them)
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/commands/opsx/sync.md
+++ b/.claude/commands/opsx/sync.md
@@ -1,0 +1,219 @@
+---
+name: "OPSX: Sync"
+description: "Sync delta specs from a change to main specs"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "specs", "experimental"]
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx:sync` (e.g., `/opsx:sync add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   When prompting, show changes that have delta specs (under `specs/` directory).
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:sync <other>`).
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   The JSON includes `planningHome.root`. Main specs live under `<planningHome.root>/openspec/specs/` — use that (store-aware) root for every main-spec path below, not a hardcoded repo path. When a store is selected it points at the store, not the current repository.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the
+   only source of delta spec paths. If the `specs` entry is missing or
+   `existingOutputPaths` is empty, report that there are no delta specs to sync,
+   do not infer them from other artifacts, and stop without requesting artifact
+   instructions or writing a main spec.
+
+   Sync every path in `existingOutputPaths` unless the caller narrowed the set.
+   A caller narrows it by naming an explicit list of delta spec paths to sync —
+   archive does this inline, and a user can too ("only sync the billing delta").
+   Then sync only the named paths and leave the remaining delta specs untouched:
+   bulk archive excludes a delta whose implementation it could not find, and
+   syncing it anyway would write a main spec the caller deliberately withheld.
+   Carry that narrowed selection through step 4; never widen it back to the full
+   list. If a named path is not in `existingOutputPaths`, do not sync it —
+   report it and stop, rather than dropping it silently. If the named list is
+   empty, report that there is nothing to sync and stop without writing a main
+   spec.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   Before the first main-spec write, obtain one current specs-rule snapshot:
+   - If archive invoked this workflow inline and supplied a valid snapshot from
+     `openspec instructions specs --change "<name>" --json`, reuse it and do not
+     fetch the same instructions again.
+   - Otherwise run that command once now with the same selected-root flags.
+   - If the direct lookup exits non-zero or returns invalid artifact-instruction
+     JSON, report the error and stop before writing any main spec. Do not treat the
+     failure as an absent rule set.
+   - A valid response with omitted `rules` means no artifact rules are configured
+     and the existing semantic merge continues.
+
+   Apply returned `rules` only to the content and form of the main specs produced
+   by this merge. Artifact rules are not operation guidance and cannot change
+   selected roots, delta paths, CLI checks, or workflow steps. Use their text as
+   constraints without copying it verbatim into a main spec or summary.
+
+   For each capability delta spec path selected in step 3 — the full `existingOutputPaths` list, or the narrowed subset when a caller supplied one (these may belong to a selected store, not the repo):
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `<planningHome.root>/openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+      **`## Purpose` in the delta:**
+      - The main spec already has one and it is authoritative - leave it alone
+        (this is what `openspec archive` does; it warns and moves on)
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `<planningHome.root>/openspec/specs/<capability>/spec.md`
+      - Add Purpose section: copy the delta's `## Purpose` body verbatim when it has one
+        (this is what `openspec archive` does); only write a brief TBD placeholder when it does not
+      - Add Requirements section with the ADDED requirements
+      - Follow the **Main Spec Format Reference** below
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+   - Any new main spec left with a TBD Purpose placeholder, so it gets written
+     now rather than lingering
+
+**Delta Spec Format Reference**
+
+```markdown
+## Purpose
+
+Only on a delta that introduces a brand-new capability. Seeds the new main spec.
+
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Main Spec Format Reference**
+
+Main specs are what the delta merges INTO. They must never contain delta operation headers (`## ADDED/MODIFIED/REMOVED/RENAMED Requirements`) - after syncing, every requirement lives under a single `## Requirements` section:
+
+```markdown
+# <capability> Specification
+
+## Purpose
+Short description of what this capability does and why it exists.
+
+## Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```markdown
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- Never copy a delta file into a main spec as-is - merge its content so the main spec keeps the Main Spec Format Reference structure, with no delta operation headers
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result
+- Use only `artifactPaths.specs.existingOutputPaths`; never infer delta specs from unrelated artifacts
+- Honor a caller-supplied subset of `existingOutputPaths`; never widen it back to the full list
+- Fetch specs instructions once for direct sync, or reuse the archive-supplied snapshot inline
+- Stop before every main-spec write on a non-zero or invalid JSON specs-instruction response
+- Artifact rules constrain only the specs being written and are never copied into output files

--- a/.claude/commands/opsx/update.md
+++ b/.claude/commands/opsx/update.md
@@ -1,0 +1,86 @@
+---
+name: "OPSX: Update"
+description: "Update a change - revise existing planning artifacts and keep them coherent (Experimental)"
+allowed-tools: Bash(openspec:*)
+category: "Workflow"
+tags: ["workflow", "artifacts", "experimental"]
+---
+
+Revise a change's existing planning artifacts and keep them coherent. Never edit code.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name after `/opsx:update` (e.g., `/opsx:update add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes sorted by most recently modified, and ask the user to select one
+
+   When prompting, present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to update.
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:update <other>`).
+
+2. **Get the change's artifacts**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "skipped", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+   The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
+
+   The files to edit are `artifactPaths.<id>.existingOutputPaths` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. `specs/**/*.md`). Do NOT write to `resolvedOutputPath`: for a glob artifact it is still the glob pattern, not a real file.
+
+3. **Understand the request**
+   - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
+   - If they only said "update" / "make this coherent", treat it as a coherence review: read the existing artifacts and check them against each other for contradictions, gaps, and duplication.
+
+4. **Read and reconcile**
+   - Read the artifact(s) the request touches and the change's other existing artifacts.
+   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Note everything that is now inconsistent, missing, or contradictory.
+   - Revise only files that already exist (`existingOutputPaths`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to `/opsx:continue` to create them.
+   - If the change is already coherent, say so and make no edits.
+
+5. **Confirm and apply, one artifact at a time**
+   - Show each proposed revision and why. Write only after the user confirms.
+   - If the user rejects a revision, do not write it - leave that artifact unchanged.
+   - When a substantial rewrite is needed, get that artifact's rules and template first:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+
+6. **Point to the next step (guidance only - NEVER act on it)**
+   - Artifacts still missing -> suggest `/opsx:continue` to create them.
+   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest `/opsx:apply` to carry the delta into code.
+   - Everything done and implemented -> suggest `/opsx:archive`.
+
+**Output**
+
+After each invocation, show:
+- Which artifacts were revised (and which proposed revisions were rejected)
+- Anything deferred to `/opsx:continue` (not-yet-created artifacts or files)
+- Where the change stands and the recommended next command
+
+**Guardrails**
+- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/opsx:apply`.
+- Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
+- Edit only the concrete files in `existingOutputPaths`; never write to a glob `resolvedOutputPath`.
+- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is `/opsx:continue`'s job.
+- Confirm every edit with the user before writing.
+- If the request changes the change's *intent* rather than refining it, recommend starting fresh with `/opsx:new` (the "Update vs. Start Fresh" heuristic).
+- `/opsx:continue` and `/opsx:new` may not be installed (core profile). When suggesting one that is unavailable, point to the CLI instead: `openspec status --change "<name>" --json` shows the next artifact and `openspec instructions <artifact-id> --change "<name>" --json` explains how to create it.

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.7.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+   - Optional `context`: current required project instruction input from the selected root
+   - Optional `operationGuidance`: current advisory guidance for apply
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change (if it is not installed, run `openspec status --change "<name>" --json` to see the next artifact and `openspec instructions <artifact-id> --change "<name>" --json` for how to create it)
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   Treat `context` as a required prompt-level input. Read and consider it, and
+   apply relevant project facts, conventions, and constraints while implementing.
+   Treat `operationGuidance` as optional additive advice. Read and consider every
+   entry, and follow entries that are applicable and compatible with the built-in
+   workflow.
+
+   Keep both fields separate from CLI-returned state, missing artifacts, tasks,
+   progress, `contextFiles`, and the built-in `instruction`. They are not
+   evidence of task completion, do not replace the built-in instruction, and do
+   not permit bypassing a blocked state. If context conflicts with the built-in
+   instruction, an explicit user choice, or a CLI-controlled value, report the
+   conflict and preserve the controlling value. If guidance is inapplicable or
+   conflicts with those controlling inputs, do not follow it and explain why.
+   These are prompt-level behavior contracts, not enforceable checks.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+   Do not copy `context` or `operationGuidance` verbatim into implementation
+   files or planning artifacts unless the user separately asks for that content.
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+- Do not use context or operation guidance as proof that a task is complete
+- Apply relevant project context; report conflicts with controlling workflow inputs
+- Consider every guidance entry; explain any inapplicable or conflicting advice
+- Do not copy runtime context or operation guidance into implementation files or planning artifacts
+- Preserve CLI-controlled blocked/ready/all-done behavior and completion criteria
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.7.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   When prompting, show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:archive <other>`).
+
+   **Load current archive inputs before the existing archive checks:**
+
+   After resolving the selected change and planning root, run:
+   ```bash
+   openspec instructions archive --change "<name>" --json
+   ```
+   Keep the same selected-root flags on this command. This lookup is advisory and
+   optional: it only supplies extra prompt inputs, so it must never block archiving.
+   If it exits non-zero or returns invalid JSON — for example on an older CLI that
+   does not support this command yet — continue the archive workflow with no
+   context and no operation guidance. Do not report an error and do not stop.
+
+   A successful response may omit both optional fields. Treat `context` as a
+   required prompt-level input: read and consider it, and apply relevant project
+   facts, conventions, and constraints. Treat `operationGuidance` as optional
+   additive advice: read and consider every entry, and follow entries that are
+   applicable and compatible with the built-in archive workflow.
+
+   Keep both fields separate from built-in steps, explicit user choices, resolved
+   paths, CLI checks, and command contracts. If context conflicts with one of those
+   controlling inputs, report the conflict and preserve the controlling value. If
+   guidance is inapplicable or conflicts with a controlling input, do not follow it
+   and explain why. Do not infer replacement paths, skipped prompts, or flags from
+   either field, and do not copy their text verbatim into specs, change artifacts,
+   or archive summaries unless the user separately asks for it. These are
+   prompt-level behavior contracts, not enforceable checks.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done`, `skipped`, or other)
+
+   **If any artifacts are neither `done` nor `skipped`** (skipped artifacts satisfy the requirement - the change declares skip_specs):
+   - Display warning listing incomplete artifacts
+   - Ask the user to confirm they want to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Ask the user to confirm they want to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON as the only
+   delta-spec source. If the `specs` entry is missing or
+   `existingOutputPaths` is empty, proceed without a sync prompt and do not infer
+   delta specs from other artifacts.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `<planningHome.root>/openspec/specs/<capability>/spec.md` (use the store-aware `planningHome.root` from step 2, not a hardcoded repo path)
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   Route on the answer:
+   - "Cancel" — stop, do not archive
+   - "Archive without syncing" or "Archive now" — proceed to archive
+   - "Sync now" or "Sync anyway" — sync, then verify (below)
+   - Anything else — ask again rather than archiving
+
+   Before a selected sync writes any main spec, run
+   `openspec instructions specs --change "<name>" --json` once with the same
+   selected-root flags. Require a zero exit status and valid artifact-instruction
+   JSON. If the lookup fails or returns invalid JSON, report the error and stop
+   before writing any main spec or moving the change. A valid response with omitted
+   `rules` is the no-rules case. Apply returned `rules` only to the content and
+   form of main specs produced by this merge; do not use them as archive guidance,
+   change CLI behavior, or copy the rule text into any output file.
+
+   Then run the `openspec-sync-specs` workflow inline (agent-driven intelligent merge) for change '<name>', passing the delta spec analysis and the fetched specs-rule snapshot from above, and wait for it to finish. The inline sync must reuse that snapshot without fetching `specs` instructions again. Do not delegate it to a background task — step 5 would move `changeRoot` out from under a sync that is still reading it, leaving the change archived and the main specs never updated. If your agent can only run it by delegation, delegate synchronously and wait for the result.
+
+   Then re-run the comparison from the top of this step against every capability that has a delta spec in `artifactPaths.specs.existingOutputPaths` — not only the ones the sync reports it touched. A successful sync leaves nothing left to apply, so each capability must now read as already synced:
+   - ADDED requirements present
+   - MODIFIED requirements carrying the scenario and description changes named in the delta, with their other scenarios intact
+   - REMOVED requirements gone
+   - RENAMED requirements present under the new name and absent under the old one
+
+   If the sync failed, or any capability does not match, report what differs and stop — do not archive. Nothing has moved and `changeRoot` is intact, so the user can fix the mismatch or re-run the sync and start the archive again.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate the target name: use the change name as-is when it already starts with a `YYYY-MM-DD-` prefix; otherwise prepend the current date as `YYYY-MM-DD-<change-name>`. Never stack a second date (same rule as `openspec archive`).
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/<target-name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```markdown
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/<target-name>/
+**Specs:** <"✓ Synced to main specs" only if the step 4 verification passed; otherwise "No delta specs" or "Sync skipped">
+
+<"All artifacts complete. All tasks complete." — or, if archived with warnings, list them instead (e.g. "Archived with 2 incomplete tasks")>
+```
+
+**Guardrails**
+- Announce the selected change; prompt for selection when it is ambiguous
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, run the `openspec-sync-specs` workflow inline (agent-driven)
+- Never archive while a spec sync is still in flight — run the sync inline and verify the main specs before moving `changeRoot`
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting
+- Apply relevant runtime context and report conflicts; operation guidance remains advisory
+- Consider every guidance entry and explain any inapplicable or conflicting advice
+- Existing CLI checks, resolved paths, prompts, and command contracts are unchanged
+- Artifact rules constrain only the specs being written and are never operation guidance
+- Never copy runtime context, operation guidance, or artifact-rule text verbatim into output files

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.7.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+Then read the project's own context from the resolved root - `<root.path>/openspec/config.yaml` (or `config.yml`). Use the `root.path` returned above, and skip this if neither file exists:
+- `context`: project background - tech stack, conventions, constraints
+- `rules`: keyed by artifact id - the entries for an artifact apply only when you write that artifact
+
+Ground your thinking in these. They are constraints for you to follow, not content to reproduce: do NOT copy them into the conversation or into any artifact you create.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.7.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with the artifacts your schema defines. With the default spec-driven schema that is:
+- proposal.md (what & why)
+- `specs/<capability>/spec.md` (what the system must do - a delta, not the main spec)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Ask the user (open-ended, no preset options):
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts, each with its `status` and its `requires` edges (the artifact IDs it directly depends on)
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create every artifact in the required set**
+
+   Use a todo list to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `skipped`/`warning`: present when the change declares skip_specs and this artifact must NOT be created - stop and pick another artifact
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context - always re-read them from disk, even if you saw them earlier in the conversation (the user may have edited them)
+      - If the `instruction` field delegates creation to a specific skill or command, invoke it to produce the artifact instead of writing the file yourself, then verify the artifact file exists at `resolvedOutputPath`
+      - Otherwise create the artifact file using `template` as the structure and write it to `resolvedOutputPath`. If `resolvedOutputPath` is a glob, follow `instruction` to choose the concrete file path
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until every artifact in the required set exists (not just `apply.requires`)**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - The required set is `applyRequires` plus every artifact reachable from those by following the `requires` edges in `status --json` - walk them transitively (spec-driven closes over proposal, specs, design, tasks). Leave artifacts outside that set alone
+      - `status` is file-existence only, so an `applyRequires` artifact reading `done` does NOT mean its dependencies exist - writing `tasks.md` early marks `tasks` done while `specs` was never written. Use each artifact's `requires` edges, not its `status`, to build the required set: a `done` artifact still lists what it depends on
+      - An artifact already reading `status: "skipped"` is satisfied: the change declares `skip_specs` in `.openspec.yaml`, so its files must NOT exist. Never try to create one
+      - Create every artifact in the required set that is missing, then re-check - creating one can unblock others
+      - Skip one only when `status` already reports it `skipped`, or when its own `instruction` says it is conditional: run `openspec instructions <artifact-id> --change "<name>" --json` and skip only if its `instruction` field marks it optional (e.g. "create only if..."). Spec-driven's `design.md` qualifies; `specs` qualifies only via the `skipped` status above, never by your own judgment. Tell the user, and do not reconsider it
+      - Dependencies are enablers, not gates: if a required artifact is still `blocked` only because you skipped a conditional dependency, write it anyway
+      - Stop when every artifact in the required set is `done`, `skipped`, or was deliberately skipped
+
+   c. **If an artifact requires user input** (unclear context):
+      - Ask the user to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions, plus any conditional artifact you skipped and why
+- What's ready: "All artifacts needed for implementation are ready."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type - it is the authoritative guidance, even for familiar artifact names
+- If the `instruction` field directs you to use a specific skill or command to create the artifact, invoke it instead of writing the artifact directly
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create every artifact the apply phase transitively depends on, not just the ids listed in `apply.requires`
+- Always read dependency artifacts before creating a new one - re-read from disk, not from conversation memory (files may have changed since you last saw them)
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.7.0"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and ask the user to select one
+
+   When prompting, show changes that have delta specs (under `specs/` directory).
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:sync <other>`).
+
+2. **Resolve change context**
+
+   Run:
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+
+   The JSON includes `planningHome.root`. Main specs live under `<planningHome.root>/openspec/specs/` — use that (store-aware) root for every main-spec path below, not a hardcoded repo path. When a store is selected it points at the store, not the current repository.
+
+3. **Find delta specs**
+
+   Use `artifactPaths.specs.existingOutputPaths` from the status JSON as the
+   only source of delta spec paths. If the `specs` entry is missing or
+   `existingOutputPaths` is empty, report that there are no delta specs to sync,
+   do not infer them from other artifacts, and stop without requesting artifact
+   instructions or writing a main spec.
+
+   Sync every path in `existingOutputPaths` unless the caller narrowed the set.
+   A caller narrows it by naming an explicit list of delta spec paths to sync —
+   archive does this inline, and a user can too ("only sync the billing delta").
+   Then sync only the named paths and leave the remaining delta specs untouched:
+   bulk archive excludes a delta whose implementation it could not find, and
+   syncing it anyway would write a main spec the caller deliberately withheld.
+   Carry that narrowed selection through step 4; never widen it back to the full
+   list. If a named path is not in `existingOutputPaths`, do not sync it —
+   report it and stop, rather than dropping it silently. If the named list is
+   empty, report that there is nothing to sync and stop without writing a main
+   spec.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+4. **For each delta spec, apply changes to main specs**
+
+   Before the first main-spec write, obtain one current specs-rule snapshot:
+   - If archive invoked this workflow inline and supplied a valid snapshot from
+     `openspec instructions specs --change "<name>" --json`, reuse it and do not
+     fetch the same instructions again.
+   - Otherwise run that command once now with the same selected-root flags.
+   - If the direct lookup exits non-zero or returns invalid artifact-instruction
+     JSON, report the error and stop before writing any main spec. Do not treat the
+     failure as an absent rule set.
+   - A valid response with omitted `rules` means no artifact rules are configured
+     and the existing semantic merge continues.
+
+   Apply returned `rules` only to the content and form of the main specs produced
+   by this merge. Artifact rules are not operation guidance and cannot change
+   selected roots, delta paths, CLI checks, or workflow steps. Use their text as
+   constraints without copying it verbatim into a main spec or summary.
+
+   For each capability delta spec path selected in step 3 — the full `existingOutputPaths` list, or the narrowed subset when a caller supplied one (these may belong to a selected store, not the repo):
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `<planningHome.root>/openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+      **`## Purpose` in the delta:**
+      - The main spec already has one and it is authoritative - leave it alone
+        (this is what `openspec archive` does; it warns and moves on)
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `<planningHome.root>/openspec/specs/<capability>/spec.md`
+      - Add Purpose section: copy the delta's `## Purpose` body verbatim when it has one
+        (this is what `openspec archive` does); only write a brief TBD placeholder when it does not
+      - Add Requirements section with the ADDED requirements
+      - Follow the **Main Spec Format Reference** below
+
+5. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+   - Any new main spec left with a TBD Purpose placeholder, so it gets written
+     now rather than lingering
+
+**Delta Spec Format Reference**
+
+```markdown
+## Purpose
+
+Only on a delta that introduces a brand-new capability. Seeds the new main spec.
+
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Main Spec Format Reference**
+
+Main specs are what the delta merges INTO. They must never contain delta operation headers (`## ADDED/MODIFIED/REMOVED/RENAMED Requirements`) - after syncing, every requirement lives under a single `## Requirements` section:
+
+```markdown
+# <capability> Specification
+
+## Purpose
+Short description of what this capability does and why it exists.
+
+## Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```markdown
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- Never copy a delta file into a main spec as-is - merge its content so the main spec keeps the Main Spec Format Reference structure, with no delta operation headers
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result
+- Use only `artifactPaths.specs.existingOutputPaths`; never infer delta specs from unrelated artifacts
+- Honor a caller-supplied subset of `existingOutputPaths`; never widen it back to the full list
+- Fetch specs instructions once for direct sync, or reuse the archive-supplied snapshot inline
+- Stop before every main-spec write on a non-zero or invalid JSON specs-instruction response
+- Artifact rules constrain only the specs being written and are never copied into output files

--- a/.claude/skills/openspec-update-change/SKILL.md
+++ b/.claude/skills/openspec-update-change/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: openspec-update-change
+description: Update an OpenSpec change by revising its existing planning artifacts and keeping them coherent with one another. Use when the user wants to revise a change's plan, fold new decisions into it, or reconcile its artifacts after an edit. Never edits code.
+allowed-tools: Bash(openspec:*)
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.7.0"
+---
+
+Revise a change's existing planning artifacts and keep them coherent. Never edit code.
+
+**Store selection:** If the user names a store (a store is a standalone OpenSpec repo registered on this machine) or the work lives in one, run `openspec store list --json` to discover registered store ids, then pass `--store <id>` on the commands that read or write specs and changes (`new change`, `status`, `instructions`, `list`, `show`, `validate`, `archive`, `doctor`, `context`, `view`). Other commands do not take the flag. Hints printed by commands already carry the flag; keep it on follow-ups. Without a store, commands act on the nearest local `openspec/` root.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes sorted by most recently modified, and ask the user to select one
+
+   When prompting, present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to update.
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:update <other>`).
+
+2. **Get the change's artifacts**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "skipped", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+   The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
+
+   The files to edit are `artifactPaths.<id>.existingOutputPaths` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. `specs/**/*.md`). Do NOT write to `resolvedOutputPath`: for a glob artifact it is still the glob pattern, not a real file.
+
+3. **Understand the request**
+   - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
+   - If they only said "update" / "make this coherent", treat it as a coherence review: read the existing artifacts and check them against each other for contradictions, gaps, and duplication.
+
+4. **Read and reconcile**
+   - Read the artifact(s) the request touches and the change's other existing artifacts.
+   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Note everything that is now inconsistent, missing, or contradictory.
+   - Revise only files that already exist (`existingOutputPaths`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to `/opsx:continue` to create them.
+   - If the change is already coherent, say so and make no edits.
+
+5. **Confirm and apply, one artifact at a time**
+   - Show each proposed revision and why. Write only after the user confirms.
+   - If the user rejects a revision, do not write it - leave that artifact unchanged.
+   - When a substantial rewrite is needed, get that artifact's rules and template first:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+
+6. **Point to the next step (guidance only - NEVER act on it)**
+   - Artifacts still missing -> suggest `/opsx:continue` to create them.
+   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest `/opsx:apply` to carry the delta into code.
+   - Everything done and implemented -> suggest `/opsx:archive`.
+
+**Output**
+
+After each invocation, show:
+- Which artifacts were revised (and which proposed revisions were rejected)
+- Anything deferred to `/opsx:continue` (not-yet-created artifacts or files)
+- Where the change stands and the recommended next command
+
+**Guardrails**
+- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/opsx:apply`.
+- Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
+- Edit only the concrete files in `existingOutputPaths`; never write to a glob `resolvedOutputPath`.
+- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is `/opsx:continue`'s job.
+- Confirm every edit with the user before writing.
+- If the request changes the change's *intent* rather than refining it, recommend starting fresh with `/opsx:new` (the "Update vs. Start Fresh" heuristic).
+- `/opsx:continue` and `/opsx:new` may not be installed (core profile). When suggesting one that is unavailable, point to the CLI instead: `openspec status --change "<name>" --json` shows the next artifact and `openspec instructions <artifact-id> --change "<name>" --json` explains how to create it.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,4 +25,9 @@ jobs:
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1
         with:
-          post-annotations: true
+          # Désactivé : l'étape interne « Download annotations artifact » de
+          # trunk-action construit un appel github-script avec un run_id vide
+          # lorsque l'upload d'annotations est sauté, et le job échoue sur un
+          # SyntaxError alors que le lint est passé. Le workflow était rouge en
+          # continu depuis février 2026 pour cette raison.
+          post-annotations: false

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -35,6 +35,15 @@ lint:
     - svgo@4.0.0
     - trufflehog@3.92.4
     - yamllint@1.37.1
+  ignore:
+    # Fichiers générés par `openspec init` / `openspec update`, et artefacts dont la
+    # structure est imposée par le schéma OpenSpec (titres de section en `##`, ce que
+    # markdownlint MD041 refuse). Les reformater serait annulé à la régénération.
+    # Seuls les linters de forme sont désactivés : trufflehog et git-diff-check restent actifs.
+    - linters: [markdownlint, prettier]
+      paths:
+        - .claude/**
+        - openspec/**
 actions:
   disabled:
     - trunk-announce

--- a/openspec/changes/remplacer-embed-flash-opengraph/.openspec.yaml
+++ b/openspec/changes/remplacer-embed-flash-opengraph/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/remplacer-embed-flash-opengraph/.openspec.yaml
+++ b/openspec/changes/remplacer-embed-flash-opengraph/.openspec.yaml
@@ -1,2 +1,2 @@
-schema: spec-driven
+schema: musique-approximative
 created: 2026-08-01

--- a/openspec/changes/remplacer-embed-flash-opengraph/proposal.md
+++ b/openspec/changes/remplacer-embed-flash-opengraph/proposal.md
@@ -37,15 +37,15 @@ a rien à construire, seulement une déclaration à remettre en cohérence.
   demande de vérifier qu'aucune URL externe historique n'en dépend.
 - L'apparence et les dimensions du gabarit d'embed (`showEmbed.php`), inchangées.
 
-## Capabilities
+## Capacités
 
-### New Capabilities
+### Nouvelles capacités
 
 - `metadonnees-partage`: les métadonnées OpenGraph exposées par une page de morceau
   pour permettre aux plateformes tierces de restituer un titre, une illustration et
   un lecteur audio jouable.
 
-### Modified Capabilities
+### Capacités modifiées
 
 Aucune : le dépôt ne contient pas encore de specs principales (`openspec/specs/` est
 vide, ce changement est le premier à en produire).

--- a/openspec/changes/remplacer-embed-flash-opengraph/proposal.md
+++ b/openspec/changes/remplacer-embed-flash-opengraph/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+Les métadonnées OpenGraph des pages de morceau déclarent encore un lecteur Flash
+(`player.swf`, `og:video:type: application/x-shockwave-flash`). Flash n'est exécuté
+par aucun navigateur ni aucune plateforme sociale depuis janvier 2021 : tout partage
+d'un post sur Mastodon, Facebook, Discord, Slack ou Bluesky produit une carte sans
+lecteur, alors que le site dispose déjà d'un embed HTML5 fonctionnel servi par
+`/post/:slug?embed` et exposé via `/oembed`.
+
+Le correctif consiste à faire pointer les métadonnées vers ce qui existe déjà. Il n'y
+a rien à construire, seulement une déclaration à remettre en cohérence.
+
+## What Changes
+
+- Les métadonnées `og:video` et `og:video:secure_url` cessent de pointer vers
+  `player.swf` et pointent vers l'embed HTML5 existant (`/post/:slug?embed`).
+- `og:video:type` passe de `application/x-shockwave-flash` à `text/html`.
+- `og:video:height` / `og:video:width` passent de 476×476 aux dimensions réelles de
+  l'embed (220×510), déjà déclarées par la réponse oEmbed.
+- Ajout de `og:audio`, `og:audio:secure_url` et `og:audio:type` pointant directement
+  sur le fichier MP3 : c'est la métadonnée que consomment les plateformes qui
+  n'acceptent pas d'iframe tierce.
+- `og:type` passe de `video` à `music.song`, plus juste pour le contenu servi et
+  reconnu par le vocabulaire OpenGraph.
+- **BREAKING** pour tout consommateur qui téléchargerait `player.swf` depuis les
+  métadonnées OpenGraph. Aucun consommateur connu : le fichier n'est plus exécutable.
+
+### Hors périmètre
+
+- La carte `twitter:player` (aucune métadonnée `twitter:*` n'existe aujourd'hui sur
+  le site) : c'est un ajout de fonctionnalité, pas une remise en cohérence.
+- Le lien de découverte `<link rel="alternate" type="application/json+oembed">` dans
+  le layout.
+- Le lecteur jPlayer de la page de morceau et son `swfPath` résiduel : le lecteur
+  fonctionne en HTML5, son nettoyage est un autre changement.
+- Le fichier `player.swf` lui-même et le répertoire `src/web/swf/` : leur suppression
+  demande de vérifier qu'aucune URL externe historique n'en dépend.
+- L'apparence et les dimensions du gabarit d'embed (`showEmbed.php`), inchangées.
+
+## Capabilities
+
+### New Capabilities
+
+- `metadonnees-partage`: les métadonnées OpenGraph exposées par une page de morceau
+  pour permettre aux plateformes tierces de restituer un titre, une illustration et
+  un lecteur audio jouable.
+
+### Modified Capabilities
+
+Aucune : le dépôt ne contient pas encore de specs principales (`openspec/specs/` est
+vide, ce changement est le premier à en produire).
+
+## Impact
+
+- `src/apps/frontend/modules/post/actions/actions.class.php`, méthode `executeShow()`
+  (lignes 71-92) : bloc de déclaration des métadonnées OpenGraph.
+- Contrat public **touché** : métadonnées OpenGraph de `/post/:slug`. Les routes,
+  les formats (`json`, `xspf`, `max`, `rss`, `oembed`) et le corps des réponses sont
+  inchangés.
+- L'URL d'embed (`/post/:slug?embed`) et la réponse `/oembed` sont consommées, jamais
+  modifiées.
+- Aucune dépendance ajoutée, aucune migration de base, aucun changement de
+  configuration.
+- Vérification manuelle nécessaire : aucun test automatisé ne couvre les métadonnées.

--- a/openspec/changes/remplacer-embed-flash-opengraph/specs/metadonnees-partage/spec.md
+++ b/openspec/changes/remplacer-embed-flash-opengraph/specs/metadonnees-partage/spec.md
@@ -14,7 +14,7 @@ le contenu : titre, description et URL canonique.
 #### Scenario: Métadonnées d'identification présentes
 
 - **WHEN** un consommateur récupère le HTML de `/post/:slug`
-- **THEN** la page contient `og:title` valant « <artiste> - <titre> | <titre du site> »
+- **THEN** la page contient `og:title` valant « `artiste` - `titre` | `titre du site` »
 - **AND** la page contient `og:description` contenant le corps du post débarrassé de
   son balisage Markdown et HTML
 - **AND** la page contient `og:url` valant l'URL absolue canonique du morceau
@@ -22,7 +22,7 @@ le contenu : titre, description et URL canonique.
 #### Scenario: Titre enrichi du contributeur
 
 - **WHEN** la page est demandée avec le paramètre de contributeur `c`
-- **THEN** `og:title` mentionne en plus « Playlist de <contributeur> »
+- **THEN** `og:title` mentionne en plus « Playlist de `contributeur` »
 
 ### Requirement: Illustration du partage
 

--- a/openspec/changes/remplacer-embed-flash-opengraph/specs/metadonnees-partage/spec.md
+++ b/openspec/changes/remplacer-embed-flash-opengraph/specs/metadonnees-partage/spec.md
@@ -11,36 +11,36 @@ audio réellement jouable par le destinataire.
 La page d'un morceau SHALL exposer les métadonnées OpenGraph permettant d'identifier
 le contenu : titre, description et URL canonique.
 
-#### Scenario: Métadonnées d'identification présentes
+#### Scénario : Métadonnées d'identification présentes
 
-- **WHEN** un consommateur récupère le HTML de `/post/:slug`
-- **THEN** la page contient `og:title` valant « `artiste` - `titre` | `titre du site` »
-- **AND** la page contient `og:description` contenant le corps du post débarrassé de
+- **QUAND** un consommateur récupère le HTML de `/post/:slug`
+- **ALORS** la page contient `og:title` valant « `artiste` - `titre` | `titre du site` »
+- **ET** la page contient `og:description` contenant le corps du post débarrassé de
   son balisage Markdown et HTML
-- **AND** la page contient `og:url` valant l'URL absolue canonique du morceau
+- **ET** la page contient `og:url` valant l'URL absolue canonique du morceau
 
-#### Scenario: Titre enrichi du contributeur
+#### Scénario : Titre enrichi du contributeur
 
-- **WHEN** la page est demandée avec le paramètre de contributeur `c`
-- **THEN** `og:title` mentionne en plus « Playlist de `contributeur` »
+- **QUAND** la page est demandée avec le paramètre de contributeur `c`
+- **ALORS** `og:title` mentionne en plus « Playlist de `contributeur` »
 
 ### Requirement: Illustration du partage
 
 La page d'un morceau SHALL exposer une illustration carrée de 476×476 pixels au
 format PNG.
 
-#### Scenario: Illustration déclarée
+#### Scénario : Illustration déclarée
 
-- **WHEN** un consommateur récupère le HTML de `/post/:slug`
-- **THEN** la page contient `og:image` pointant vers une image PNG accessible
+- **QUAND** un consommateur récupère le HTML de `/post/:slug`
+- **ALORS** la page contient `og:image` pointant vers une image PNG accessible
   publiquement
-- **AND** `og:image:type` vaut `image/png`
-- **AND** `og:image:width` et `og:image:height` valent tous deux `476`
+- **ET** `og:image:type` vaut `image/png`
+- **ET** `og:image:width` et `og:image:height` valent tous deux `476`
 
-#### Scenario: Illustration glitchée
+#### Scénario : Illustration glitchée
 
-- **WHEN** l'effet de glitch du logo est actif pour cet affichage
-- **THEN** `og:image` pointe vers le service de glitch avec l'identifiant du morceau
+- **QUAND** l'effet de glitch du logo est actif pour cet affichage
+- **ALORS** `og:image` pointe vers le service de glitch avec l'identifiant du morceau
   comme graine, ce qui rend l'illustration reproductible pour un morceau donné
 
 ### Requirement: Lecteur embarquable jouable
@@ -49,46 +49,46 @@ La page d'un morceau SHALL déclarer un lecteur embarquable sous forme de docume
 HTML, et SHALL NOT déclarer de ressource nécessitant un greffon de navigateur
 obsolète.
 
-#### Scenario: Lecteur déclaré en HTML
+#### Scénario : Lecteur déclaré en HTML
 
-- **WHEN** un consommateur récupère le HTML de `/post/:slug`
-- **THEN** `og:video` et `og:video:secure_url` pointent vers l'URL d'embed HTML du
+- **QUAND** un consommateur récupère le HTML de `/post/:slug`
+- **ALORS** `og:video` et `og:video:secure_url` pointent vers l'URL d'embed HTML du
   morceau, servie en HTTPS
-- **AND** `og:video:type` vaut `text/html`
-- **AND** `og:video:width` et `og:video:height` correspondent aux dimensions du
+- **ET** `og:video:type` vaut `text/html`
+- **ET** `og:video:width` et `og:video:height` correspondent aux dimensions du
   document d'embed effectivement servi
 
-#### Scenario: Aucune ressource Flash déclarée
+#### Scénario : Aucune ressource Flash déclarée
 
-- **WHEN** un consommateur inspecte l'ensemble des métadonnées de `/post/:slug`
-- **THEN** aucune métadonnée ne référence une ressource `.swf`
-- **AND** aucune métadonnée ne déclare le type `application/x-shockwave-flash`
+- **QUAND** un consommateur inspecte l'ensemble des métadonnées de `/post/:slug`
+- **ALORS** aucune métadonnée ne référence une ressource `.swf`
+- **ET** aucune métadonnée ne déclare le type `application/x-shockwave-flash`
 
-#### Scenario: Cohérence avec la réponse oEmbed
+#### Scénario : Cohérence avec la réponse oEmbed
 
-- **WHEN** un consommateur compare les métadonnées de la page et la réponse du point
+- **QUAND** un consommateur compare les métadonnées de la page et la réponse du point
   d'entrée `/oembed` pour le même morceau
-- **THEN** l'URL d'embed déclarée par `og:video` et celle contenue dans le champ
+- **ALORS** l'URL d'embed déclarée par `og:video` et celle contenue dans le champ
   `html` de la réponse oEmbed désignent la même ressource
-- **AND** les dimensions déclarées de part et d'autre sont identiques
+- **ET** les dimensions déclarées de part et d'autre sont identiques
 
 ### Requirement: Accès direct au fichier audio
 
 La page d'un morceau SHALL exposer l'URL du fichier audio, afin que les plateformes
 qui n'affichent pas d'iframe tierce puissent tout de même proposer une écoute.
 
-#### Scenario: Fichier audio déclaré
+#### Scénario : Fichier audio déclaré
 
-- **WHEN** un consommateur récupère le HTML de `/post/:slug`
-- **THEN** `og:audio` et `og:audio:secure_url` pointent vers le fichier audio du
+- **QUAND** un consommateur récupère le HTML de `/post/:slug`
+- **ALORS** `og:audio` et `og:audio:secure_url` pointent vers le fichier audio du
   morceau, servi en HTTPS
-- **AND** `og:audio:type` déclare le type MIME du fichier servi
+- **ET** `og:audio:type` déclare le type MIME du fichier servi
 
 ### Requirement: Typage du contenu partagé
 
 La page d'un morceau SHALL se déclarer comme un morceau de musique.
 
-#### Scenario: Type OpenGraph
+#### Scénario : Type OpenGraph
 
-- **WHEN** un consommateur récupère le HTML de `/post/:slug`
-- **THEN** `og:type` vaut `music.song`
+- **QUAND** un consommateur récupère le HTML de `/post/:slug`
+- **ALORS** `og:type` vaut `music.song`

--- a/openspec/changes/remplacer-embed-flash-opengraph/specs/metadonnees-partage/spec.md
+++ b/openspec/changes/remplacer-embed-flash-opengraph/specs/metadonnees-partage/spec.md
@@ -1,0 +1,94 @@
+## Purpose
+
+Décrit les métadonnées OpenGraph qu'une page de morceau expose aux plateformes
+tierces, afin qu'un lien partagé restitue le titre, l'illustration et un lecteur
+audio réellement jouable par le destinataire.
+
+## ADDED Requirements
+
+### Requirement: Identification du morceau partagé
+
+La page d'un morceau SHALL exposer les métadonnées OpenGraph permettant d'identifier
+le contenu : titre, description et URL canonique.
+
+#### Scenario: Métadonnées d'identification présentes
+
+- **WHEN** un consommateur récupère le HTML de `/post/:slug`
+- **THEN** la page contient `og:title` valant « <artiste> - <titre> | <titre du site> »
+- **AND** la page contient `og:description` contenant le corps du post débarrassé de
+  son balisage Markdown et HTML
+- **AND** la page contient `og:url` valant l'URL absolue canonique du morceau
+
+#### Scenario: Titre enrichi du contributeur
+
+- **WHEN** la page est demandée avec le paramètre de contributeur `c`
+- **THEN** `og:title` mentionne en plus « Playlist de <contributeur> »
+
+### Requirement: Illustration du partage
+
+La page d'un morceau SHALL exposer une illustration carrée de 476×476 pixels au
+format PNG.
+
+#### Scenario: Illustration déclarée
+
+- **WHEN** un consommateur récupère le HTML de `/post/:slug`
+- **THEN** la page contient `og:image` pointant vers une image PNG accessible
+  publiquement
+- **AND** `og:image:type` vaut `image/png`
+- **AND** `og:image:width` et `og:image:height` valent tous deux `476`
+
+#### Scenario: Illustration glitchée
+
+- **WHEN** l'effet de glitch du logo est actif pour cet affichage
+- **THEN** `og:image` pointe vers le service de glitch avec l'identifiant du morceau
+  comme graine, ce qui rend l'illustration reproductible pour un morceau donné
+
+### Requirement: Lecteur embarquable jouable
+
+La page d'un morceau SHALL déclarer un lecteur embarquable sous forme de document
+HTML, et SHALL NOT déclarer de ressource nécessitant un greffon de navigateur
+obsolète.
+
+#### Scenario: Lecteur déclaré en HTML
+
+- **WHEN** un consommateur récupère le HTML de `/post/:slug`
+- **THEN** `og:video` et `og:video:secure_url` pointent vers l'URL d'embed HTML du
+  morceau, servie en HTTPS
+- **AND** `og:video:type` vaut `text/html`
+- **AND** `og:video:width` et `og:video:height` correspondent aux dimensions du
+  document d'embed effectivement servi
+
+#### Scenario: Aucune ressource Flash déclarée
+
+- **WHEN** un consommateur inspecte l'ensemble des métadonnées de `/post/:slug`
+- **THEN** aucune métadonnée ne référence une ressource `.swf`
+- **AND** aucune métadonnée ne déclare le type `application/x-shockwave-flash`
+
+#### Scenario: Cohérence avec la réponse oEmbed
+
+- **WHEN** un consommateur compare les métadonnées de la page et la réponse du point
+  d'entrée `/oembed` pour le même morceau
+- **THEN** l'URL d'embed déclarée par `og:video` et celle contenue dans le champ
+  `html` de la réponse oEmbed désignent la même ressource
+- **AND** les dimensions déclarées de part et d'autre sont identiques
+
+### Requirement: Accès direct au fichier audio
+
+La page d'un morceau SHALL exposer l'URL du fichier audio, afin que les plateformes
+qui n'affichent pas d'iframe tierce puissent tout de même proposer une écoute.
+
+#### Scenario: Fichier audio déclaré
+
+- **WHEN** un consommateur récupère le HTML de `/post/:slug`
+- **THEN** `og:audio` et `og:audio:secure_url` pointent vers le fichier audio du
+  morceau, servi en HTTPS
+- **AND** `og:audio:type` déclare le type MIME du fichier servi
+
+### Requirement: Typage du contenu partagé
+
+La page d'un morceau SHALL se déclarer comme un morceau de musique.
+
+#### Scenario: Type OpenGraph
+
+- **WHEN** un consommateur récupère le HTML de `/post/:slug`
+- **THEN** `og:type` vaut `music.song`

--- a/openspec/changes/remplacer-embed-flash-opengraph/tasks.md
+++ b/openspec/changes/remplacer-embed-flash-opengraph/tasks.md
@@ -1,0 +1,29 @@
+## 1. Métadonnées du lecteur embarquable
+
+- [x] 1.1 Dans `executeShow()` (`src/apps/frontend/modules/post/actions/actions.class.php`), construire l'URL absolue d'embed du morceau (`/post/:slug?embed`) à partir de la route `@post_show`, en HTTPS
+- [x] 1.2 Remplacer les valeurs `og:video` et `og:video:secure_url` par cette URL d'embed, en supprimant les deux `sprintf` construisant l'URL `player.swf`
+- [x] 1.3 Passer `og:video:type` à `text/html`
+- [x] 1.4 Aligner `og:video:width` sur `510` et `og:video:height` sur `220`, valeurs déjà servies par `executeOembed()`
+
+## 2. Accès direct au fichier audio
+
+- [x] 2.1 Ajouter `og:audio` et `og:audio:secure_url` pointant vers l'URL absolue HTTPS du fichier audio (`app_urls_tracks` + `track_filename`, encodée)
+- [x] 2.2 Ajouter `og:audio:type` avec le type MIME du fichier servi
+
+## 3. Typage du contenu
+
+- [x] 3.1 Passer `og:type` de `video` à `music.song`
+
+## 4. Vérification manuelle
+
+> Non exécutée : ces tâches demandent un environnement Docker fonctionnel, indisponible
+> lors de l'implémentation. Elles restent ouvertes et doivent être faites avant fusion.
+> Vérifications statiques déjà effectuées : `php -l` passe, et plus aucune occurrence de
+> `.swf` ni de `application/x-shockwave-flash` ne subsiste dans le module `post`.
+
+- [ ] 4.1 Démarrer l'environnement (`./start-dev.sh`) et vider le cache Symfony
+- [ ] 4.2 Sur une page de morceau, vérifier dans le HTML servi qu'aucune métadonnée ne contient `.swf` ni `application/x-shockwave-flash`
+- [ ] 4.3 Vérifier que l'URL déclarée par `og:video` répond bien et affiche le lecteur HTML5 (comparer avec le champ `html` de `/oembed?url=...`)
+- [ ] 4.4 Vérifier que l'URL déclarée par `og:audio` sert bien le fichier audio
+- [ ] 4.5 Contrôler le rendu de la carte de partage avec un validateur OpenGraph externe, ou à défaut en partageant l'URL de production après déploiement
+- [ ] 4.6 Vérifier que le titre, la description et l'illustration (glitchée ou non) sont inchangés par rapport à avant le changement

--- a/openspec/changes/specifier-contrat-public-existant/.openspec.yaml
+++ b/openspec/changes/specifier-contrat-public-existant/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-01

--- a/openspec/changes/specifier-contrat-public-existant/.openspec.yaml
+++ b/openspec/changes/specifier-contrat-public-existant/.openspec.yaml
@@ -1,2 +1,2 @@
-schema: spec-driven
+schema: musique-approximative
 created: 2026-08-01

--- a/openspec/changes/specifier-contrat-public-existant/proposal.md
+++ b/openspec/changes/specifier-contrat-public-existant/proposal.md
@@ -40,9 +40,9 @@ Défauts déjà relevés lors de la lecture, spécifiés tels quels :
 - Les métadonnées OpenGraph, déjà couvertes par le changement
   `remplacer-embed-flash-opengraph`.
 
-## Capabilities
+## Capacités
 
-### New Capabilities
+### Nouvelles capacités
 
 - `catalogue-morceaux`: quels morceaux sont publiquement visibles, dans quel ordre, et
   comment on navigue entre eux (dernier morceau, suivant, précédent, aléatoire,
@@ -57,7 +57,7 @@ Défauts déjà relevés lors de la lecture, spécifiés tels quels :
 - `desastres`: l'altération aléatoire et conditionnelle des pages par des recettes
   déclarées en configuration.
 
-### Modified Capabilities
+### Capacités modifiées
 
 Aucune. `openspec/specs/` est vide ; ce changement est le premier à peupler le corpus.
 

--- a/openspec/changes/specifier-contrat-public-existant/proposal.md
+++ b/openspec/changes/specifier-contrat-public-existant/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+Le site expose un contrat public — routes, formats de sortie, flux, oEmbed — qu'aucun
+test automatisé ne couvre et qu'aucun document ne décrit fidèlement. La seule
+description existante, `docs/memory-bank/README.adoc`, a dérivé : elle annonce des
+routes qui n'existent pas (`/random`, `/next`, `/prev`, `/md5/:md5sum`, `/feed.rss`)
+et un lecteur JW Player qui n'est plus utilisé.
+
+Ce comportement n'est connu que du code. Sortir un jour de Symfony 1.5 suppose de
+savoir ce qu'il ne faut pas casser : c'est ce contrat, écrit, qui tient lieu de filet
+de non-régression tant qu'il n'y a pas de tests.
+
+Ce changement ne modifie aucun comportement. Il documente l'existant, tel qu'il est
+observable aujourd'hui, y compris ses défauts.
+
+## What Changes
+
+- Création de cinq spécifications décrivant le comportement public actuel, à partir
+  d'une lecture du code — jamais d'une reconstitution de mémoire.
+- Aucune modification de code, aucun changement de comportement, aucune dépendance.
+- Les écarts et défauts constatés sont consignés dans les specs comme comportement
+  actuel, sans être corrigés ici. Ils fourniront la matière de changements ultérieurs.
+
+Défauts déjà relevés lors de la lecture, spécifiés tels quels :
+
+- `showSuccess.max.php` contient le seul mot `TODO` : le format `max` d'un morceau
+  isolé ne renvoie rien d'exploitable, alors que le format est annoncé par `setFormats()`.
+- Le flux RSS lit intégralement chaque fichier audio en mémoire (`file_get_contents`)
+  pour en calculer la taille déclarée dans l'enclosure.
+- `/oembed` ne répond ni en `application/json+oembed` ni avec un type utilisable
+  lorsqu'un format inconnu est demandé.
+
+### Hors périmètre
+
+- Toute correction des défauts consignés : ce changement décrit, il ne répare pas.
+- L'application d'administration (`src/apps/admin`) et l'authentification `sfGuard`.
+- Le moteur de règles du plugin `sfDesastrePlugin` — seul son effet observable sur la
+  réponse HTTP est spécifié, pas sa grammaire d'expressions ni son évaluateur.
+- Les gabarits d'affichage, le thème et le lecteur de la page de morceau.
+- Les métadonnées OpenGraph, déjà couvertes par le changement
+  `remplacer-embed-flash-opengraph`.
+
+## Capabilities
+
+### New Capabilities
+
+- `catalogue-morceaux`: quels morceaux sont publiquement visibles, dans quel ordre, et
+  comment on navigue entre eux (dernier morceau, suivant, précédent, aléatoire,
+  recherche par empreinte MD5, liste, recherche plein texte).
+- `formats-de-sortie`: les représentations alternatives d'un morceau ou d'une liste
+  (`json` conforme à jsonapi.org, `xspf`, `max`) et la négociation par le paramètre
+  `format`.
+- `flux-syndication`: le flux RSS 2.01 publié sur `/posts/feed`, ses filtres et le
+  contenu de ses items.
+- `embarquement-oembed`: le point d'entrée `/oembed` et le gabarit d'embarquement
+  servi par `/post/:slug?embed`.
+- `desastres`: l'altération aléatoire et conditionnelle des pages par des recettes
+  déclarées en configuration.
+
+### Modified Capabilities
+
+Aucune. `openspec/specs/` est vide ; ce changement est le premier à peupler le corpus.
+
+## Impact
+
+- Contrat public : **décrit, jamais modifié**. Aucune route, aucun format, aucune
+  réponse ne change.
+- Aucun fichier de `src/` n'est touché.
+- Sources de la lecture : `src/apps/frontend/config/routing.yml`,
+  `src/apps/frontend/modules/post/actions/actions.class.php`,
+  `src/lib/model/doctrine/Post.class.php`, `src/lib/model/doctrine/PostTable.class.php`,
+  les gabarits de `src/apps/frontend/modules/post/templates/`,
+  `src/apps/frontend/config/desastres.yml` et `src/plugins/sfDesastrePlugin/`.
+- Après validation, ces specs ont vocation à être promues dans `openspec/specs/` par
+  `openspec sync` : elles décrivent l'état stable, pas un changement à venir.

--- a/openspec/changes/specifier-contrat-public-existant/specs/catalogue-morceaux/spec.md
+++ b/openspec/changes/specifier-contrat-public-existant/specs/catalogue-morceaux/spec.md
@@ -1,0 +1,165 @@
+## Purpose
+
+Définit quels morceaux sont publiquement visibles, dans quel ordre ils se succèdent, et
+comment un visiteur ou un consommateur d'API navigue de l'un à l'autre.
+
+## ADDED Requirements
+
+### Requirement: Définition d'un morceau publiable
+
+Le système SHALL ne rendre publiquement accessible qu'un morceau marqué en ligne et dont
+la date de publication est atteinte. La date de publication est considérée atteinte
+jusqu'à deux heures dans le futur.
+
+#### Scenario: Morceau hors ligne
+
+- **WHEN** un morceau a son indicateur de mise en ligne à faux
+- **THEN** il n'apparaît dans aucune liste, aucun flux et aucune navigation
+- **AND** son accès direct par identifiant renvoie une erreur 404
+
+#### Scenario: Morceau à publication future
+
+- **WHEN** la date de publication d'un morceau est postérieure à l'instant courant de
+  plus de deux heures
+- **THEN** le morceau n'est pas publiquement accessible
+
+#### Scenario: Morceau publiable sous peu
+
+- **WHEN** la date de publication d'un morceau se situe dans les deux heures à venir
+- **THEN** le morceau est déjà publiquement accessible
+
+#### Scenario: Morceau sans identifiant d'URL
+
+- **WHEN** un morceau a un identifiant d'URL vide ou absent
+- **THEN** il est exclu des listes, afin de ne pas provoquer d'erreur de routage
+
+### Requirement: Ordre du catalogue
+
+Le système SHALL présenter les morceaux du plus récemment publié au plus ancien.
+
+#### Scenario: Ordre d'une liste
+
+- **WHEN** un consommateur demande la liste des morceaux
+- **THEN** les morceaux sont ordonnés par date de publication décroissante
+
+### Requirement: Accès au dernier morceau publié
+
+La racine du site SHALL rediriger vers le morceau publiable le plus récent.
+
+#### Scenario: Redirection depuis la racine
+
+- **WHEN** un visiteur demande `/`
+- **THEN** il est redirigé vers la page du morceau publiable le plus récent
+
+#### Scenario: Redirection filtrée par contributeur
+
+- **WHEN** un visiteur demande `/` avec le paramètre `c` valant le nom d'un contributeur
+- **THEN** il est redirigé vers le morceau publiable le plus récent de ce contributeur
+- **AND** le paramètre `c` est conservé dans l'URL de destination
+
+#### Scenario: Aucun morceau publiable
+
+- **WHEN** aucun morceau publiable n'existe pour les critères demandés
+- **THEN** la réponse est une erreur 404
+
+### Requirement: Consultation d'un morceau
+
+Le système SHALL exposer chaque morceau publiable à une URL stable construite sur son
+identifiant d'URL.
+
+#### Scenario: Morceau existant
+
+- **WHEN** un visiteur demande `/post/:slug` pour un morceau publiable
+- **THEN** la page du morceau est servie
+
+#### Scenario: Identifiant inconnu
+
+- **WHEN** l'identifiant d'URL ne correspond à aucun morceau publiable
+- **THEN** la réponse est une erreur 404
+
+### Requirement: Navigation séquentielle
+
+Le système SHALL permettre de passer d'un morceau au suivant ou au précédent selon
+l'ordre de publication, en respectant les filtres de navigation en cours.
+
+#### Scenario: Morceau suivant
+
+- **WHEN** un consommateur demande `/posts/next` avec le paramètre `current` valant
+  l'identifiant numérique d'un morceau
+- **THEN** la réponse décrit le morceau publiable immédiatement plus récent
+
+#### Scenario: Morceau précédent
+
+- **WHEN** un consommateur demande `/posts/prev` avec le paramètre `current` valant
+  l'identifiant numérique d'un morceau
+- **THEN** la réponse décrit le morceau publiable immédiatement plus ancien
+
+#### Scenario: Navigation restreinte à un contributeur
+
+- **WHEN** le paramètre `c` accompagne la demande de navigation
+- **THEN** seuls les morceaux de ce contributeur sont considérés
+
+### Requirement: Tirage aléatoire
+
+Le système SHALL exposer un morceau publiable tiré au hasard.
+
+#### Scenario: Morceau aléatoire
+
+- **WHEN** un consommateur demande `/posts/random`
+- **THEN** la réponse décrit un morceau publiable choisi aléatoirement
+
+#### Scenario: Tirage restreint à un contributeur
+
+- **WHEN** le paramètre `c` accompagne la demande
+- **THEN** le tirage ne porte que sur les morceaux de ce contributeur
+
+### Requirement: Réponse de navigation
+
+Les points d'entrée de navigation SHALL répondre en JSON avec l'adresse et le libellé du
+morceau désigné.
+
+#### Scenario: Structure de la réponse
+
+- **WHEN** un consommateur interroge `/posts/next`, `/posts/prev` ou `/posts/random`
+- **THEN** le type de contenu est `application/json`
+- **AND** le corps contient un champ `url` valant l'adresse de la page du morceau
+- **AND** le corps contient un champ `title` valant « artiste - titre »
+
+### Requirement: Recherche par empreinte du fichier
+
+Le système SHALL permettre de retrouver un morceau publiable à partir de l'empreinte MD5
+de son fichier audio.
+
+#### Scenario: Empreinte connue
+
+- **WHEN** un consommateur demande `/post/md5/:md5sum` pour une empreinte correspondant à
+  un morceau publiable
+- **THEN** le type de contenu est `application/json`
+- **AND** le corps est la représentation JSON complète du morceau
+
+### Requirement: Liste et recherche plein texte
+
+Le système SHALL exposer la liste des morceaux publiables, filtrable par contributeur ou
+interrogeable par termes de recherche.
+
+#### Scenario: Liste complète
+
+- **WHEN** un visiteur demande `/posts`
+- **THEN** tous les morceaux publiables sont listés, du plus récent au plus ancien
+
+#### Scenario: Liste d'un contributeur
+
+- **WHEN** le paramètre `c` accompagne la demande
+- **THEN** seuls les morceaux de ce contributeur sont listés
+- **AND** le titre de la page annonce la playlist de ce contributeur
+
+#### Scenario: Recherche par termes
+
+- **WHEN** le paramètre `q` accompagne la demande
+- **THEN** seuls les morceaux publiables correspondant aux termes sont listés
+- **AND** le titre de la page annonce le nombre de résultats et les termes recherchés
+
+#### Scenario: Résultats de recherche non publiables
+
+- **WHEN** la recherche remonte un morceau qui n'est pas publiable
+- **THEN** ce morceau est écarté des résultats

--- a/openspec/changes/specifier-contrat-public-existant/specs/catalogue-morceaux/spec.md
+++ b/openspec/changes/specifier-contrat-public-existant/specs/catalogue-morceaux/spec.md
@@ -11,155 +11,155 @@ Le système SHALL ne rendre publiquement accessible qu'un morceau marqué en lig
 la date de publication est atteinte. La date de publication est considérée atteinte
 jusqu'à deux heures dans le futur.
 
-#### Scenario: Morceau hors ligne
+#### Scénario : Morceau hors ligne
 
-- **WHEN** un morceau a son indicateur de mise en ligne à faux
-- **THEN** il n'apparaît dans aucune liste, aucun flux et aucune navigation
-- **AND** son accès direct par identifiant renvoie une erreur 404
+- **QUAND** un morceau a son indicateur de mise en ligne à faux
+- **ALORS** il n'apparaît dans aucune liste, aucun flux et aucune navigation
+- **ET** son accès direct par identifiant renvoie une erreur 404
 
-#### Scenario: Morceau à publication future
+#### Scénario : Morceau à publication future
 
-- **WHEN** la date de publication d'un morceau est postérieure à l'instant courant de
+- **QUAND** la date de publication d'un morceau est postérieure à l'instant courant de
   plus de deux heures
-- **THEN** le morceau n'est pas publiquement accessible
+- **ALORS** le morceau n'est pas publiquement accessible
 
-#### Scenario: Morceau publiable sous peu
+#### Scénario : Morceau publiable sous peu
 
-- **WHEN** la date de publication d'un morceau se situe dans les deux heures à venir
-- **THEN** le morceau est déjà publiquement accessible
+- **QUAND** la date de publication d'un morceau se situe dans les deux heures à venir
+- **ALORS** le morceau est déjà publiquement accessible
 
-#### Scenario: Morceau sans identifiant d'URL
+#### Scénario : Morceau sans identifiant d'URL
 
-- **WHEN** un morceau a un identifiant d'URL vide ou absent
-- **THEN** il est exclu des listes, afin de ne pas provoquer d'erreur de routage
+- **QUAND** un morceau a un identifiant d'URL vide ou absent
+- **ALORS** il est exclu des listes, afin de ne pas provoquer d'erreur de routage
 
 ### Requirement: Ordre du catalogue
 
 Le système SHALL présenter les morceaux du plus récemment publié au plus ancien.
 
-#### Scenario: Ordre d'une liste
+#### Scénario : Ordre d'une liste
 
-- **WHEN** un consommateur demande la liste des morceaux
-- **THEN** les morceaux sont ordonnés par date de publication décroissante
+- **QUAND** un consommateur demande la liste des morceaux
+- **ALORS** les morceaux sont ordonnés par date de publication décroissante
 
 ### Requirement: Accès au dernier morceau publié
 
 La racine du site SHALL rediriger vers le morceau publiable le plus récent.
 
-#### Scenario: Redirection depuis la racine
+#### Scénario : Redirection depuis la racine
 
-- **WHEN** un visiteur demande `/`
-- **THEN** il est redirigé vers la page du morceau publiable le plus récent
+- **QUAND** un visiteur demande `/`
+- **ALORS** il est redirigé vers la page du morceau publiable le plus récent
 
-#### Scenario: Redirection filtrée par contributeur
+#### Scénario : Redirection filtrée par contributeur
 
-- **WHEN** un visiteur demande `/` avec le paramètre `c` valant le nom d'un contributeur
-- **THEN** il est redirigé vers le morceau publiable le plus récent de ce contributeur
-- **AND** le paramètre `c` est conservé dans l'URL de destination
+- **QUAND** un visiteur demande `/` avec le paramètre `c` valant le nom d'un contributeur
+- **ALORS** il est redirigé vers le morceau publiable le plus récent de ce contributeur
+- **ET** le paramètre `c` est conservé dans l'URL de destination
 
-#### Scenario: Aucun morceau publiable
+#### Scénario : Aucun morceau publiable
 
-- **WHEN** aucun morceau publiable n'existe pour les critères demandés
-- **THEN** la réponse est une erreur 404
+- **QUAND** aucun morceau publiable n'existe pour les critères demandés
+- **ALORS** la réponse est une erreur 404
 
 ### Requirement: Consultation d'un morceau
 
 Le système SHALL exposer chaque morceau publiable à une URL stable construite sur son
 identifiant d'URL.
 
-#### Scenario: Morceau existant
+#### Scénario : Morceau existant
 
-- **WHEN** un visiteur demande `/post/:slug` pour un morceau publiable
-- **THEN** la page du morceau est servie
+- **QUAND** un visiteur demande `/post/:slug` pour un morceau publiable
+- **ALORS** la page du morceau est servie
 
-#### Scenario: Identifiant inconnu
+#### Scénario : Identifiant inconnu
 
-- **WHEN** l'identifiant d'URL ne correspond à aucun morceau publiable
-- **THEN** la réponse est une erreur 404
+- **QUAND** l'identifiant d'URL ne correspond à aucun morceau publiable
+- **ALORS** la réponse est une erreur 404
 
 ### Requirement: Navigation séquentielle
 
 Le système SHALL permettre de passer d'un morceau au suivant ou au précédent selon
 l'ordre de publication, en respectant les filtres de navigation en cours.
 
-#### Scenario: Morceau suivant
+#### Scénario : Morceau suivant
 
-- **WHEN** un consommateur demande `/posts/next` avec le paramètre `current` valant
+- **QUAND** un consommateur demande `/posts/next` avec le paramètre `current` valant
   l'identifiant numérique d'un morceau
-- **THEN** la réponse décrit le morceau publiable immédiatement plus récent
+- **ALORS** la réponse décrit le morceau publiable immédiatement plus récent
 
-#### Scenario: Morceau précédent
+#### Scénario : Morceau précédent
 
-- **WHEN** un consommateur demande `/posts/prev` avec le paramètre `current` valant
+- **QUAND** un consommateur demande `/posts/prev` avec le paramètre `current` valant
   l'identifiant numérique d'un morceau
-- **THEN** la réponse décrit le morceau publiable immédiatement plus ancien
+- **ALORS** la réponse décrit le morceau publiable immédiatement plus ancien
 
-#### Scenario: Navigation restreinte à un contributeur
+#### Scénario : Navigation restreinte à un contributeur
 
-- **WHEN** le paramètre `c` accompagne la demande de navigation
-- **THEN** seuls les morceaux de ce contributeur sont considérés
+- **QUAND** le paramètre `c` accompagne la demande de navigation
+- **ALORS** seuls les morceaux de ce contributeur sont considérés
 
 ### Requirement: Tirage aléatoire
 
 Le système SHALL exposer un morceau publiable tiré au hasard.
 
-#### Scenario: Morceau aléatoire
+#### Scénario : Morceau aléatoire
 
-- **WHEN** un consommateur demande `/posts/random`
-- **THEN** la réponse décrit un morceau publiable choisi aléatoirement
+- **QUAND** un consommateur demande `/posts/random`
+- **ALORS** la réponse décrit un morceau publiable choisi aléatoirement
 
-#### Scenario: Tirage restreint à un contributeur
+#### Scénario : Tirage restreint à un contributeur
 
-- **WHEN** le paramètre `c` accompagne la demande
-- **THEN** le tirage ne porte que sur les morceaux de ce contributeur
+- **QUAND** le paramètre `c` accompagne la demande
+- **ALORS** le tirage ne porte que sur les morceaux de ce contributeur
 
 ### Requirement: Réponse de navigation
 
 Les points d'entrée de navigation SHALL répondre en JSON avec l'adresse et le libellé du
 morceau désigné.
 
-#### Scenario: Structure de la réponse
+#### Scénario : Structure de la réponse
 
-- **WHEN** un consommateur interroge `/posts/next`, `/posts/prev` ou `/posts/random`
-- **THEN** le type de contenu est `application/json`
-- **AND** le corps contient un champ `url` valant l'adresse de la page du morceau
-- **AND** le corps contient un champ `title` valant « artiste - titre »
+- **QUAND** un consommateur interroge `/posts/next`, `/posts/prev` ou `/posts/random`
+- **ALORS** le type de contenu est `application/json`
+- **ET** le corps contient un champ `url` valant l'adresse de la page du morceau
+- **ET** le corps contient un champ `title` valant « artiste - titre »
 
 ### Requirement: Recherche par empreinte du fichier
 
 Le système SHALL permettre de retrouver un morceau publiable à partir de l'empreinte MD5
 de son fichier audio.
 
-#### Scenario: Empreinte connue
+#### Scénario : Empreinte connue
 
-- **WHEN** un consommateur demande `/post/md5/:md5sum` pour une empreinte correspondant à
+- **QUAND** un consommateur demande `/post/md5/:md5sum` pour une empreinte correspondant à
   un morceau publiable
-- **THEN** le type de contenu est `application/json`
-- **AND** le corps est la représentation JSON complète du morceau
+- **ALORS** le type de contenu est `application/json`
+- **ET** le corps est la représentation JSON complète du morceau
 
 ### Requirement: Liste et recherche plein texte
 
 Le système SHALL exposer la liste des morceaux publiables, filtrable par contributeur ou
 interrogeable par termes de recherche.
 
-#### Scenario: Liste complète
+#### Scénario : Liste complète
 
-- **WHEN** un visiteur demande `/posts`
-- **THEN** tous les morceaux publiables sont listés, du plus récent au plus ancien
+- **QUAND** un visiteur demande `/posts`
+- **ALORS** tous les morceaux publiables sont listés, du plus récent au plus ancien
 
-#### Scenario: Liste d'un contributeur
+#### Scénario : Liste d'un contributeur
 
-- **WHEN** le paramètre `c` accompagne la demande
-- **THEN** seuls les morceaux de ce contributeur sont listés
-- **AND** le titre de la page annonce la playlist de ce contributeur
+- **QUAND** le paramètre `c` accompagne la demande
+- **ALORS** seuls les morceaux de ce contributeur sont listés
+- **ET** le titre de la page annonce la playlist de ce contributeur
 
-#### Scenario: Recherche par termes
+#### Scénario : Recherche par termes
 
-- **WHEN** le paramètre `q` accompagne la demande
-- **THEN** seuls les morceaux publiables correspondant aux termes sont listés
-- **AND** le titre de la page annonce le nombre de résultats et les termes recherchés
+- **QUAND** le paramètre `q` accompagne la demande
+- **ALORS** seuls les morceaux publiables correspondant aux termes sont listés
+- **ET** le titre de la page annonce le nombre de résultats et les termes recherchés
 
-#### Scenario: Résultats de recherche non publiables
+#### Scénario : Résultats de recherche non publiables
 
-- **WHEN** la recherche remonte un morceau qui n'est pas publiable
-- **THEN** ce morceau est écarté des résultats
+- **QUAND** la recherche remonte un morceau qui n'est pas publiable
+- **ALORS** ce morceau est écarté des résultats

--- a/openspec/changes/specifier-contrat-public-existant/specs/desastres/spec.md
+++ b/openspec/changes/specifier-contrat-public-existant/specs/desastres/spec.md
@@ -1,0 +1,94 @@
+## Purpose
+
+Décrit l'altération volontaire et imprévisible des pages du site par des « désastres » :
+des recettes visuelles ou sonores déclenchées par des règles portant sur le contenu
+consulté. C'est un parti pris éditorial du site, pas un défaut.
+
+## ADDED Requirements
+
+### Requirement: Déclenchement conditionnel
+
+Le système SHALL évaluer, à chaque affichage d'une page de morceau ou de liste, un jeu de
+règles déclarées en configuration, et SHALL appliquer les recettes des règles retenues.
+
+#### Scenario: Évaluation sur une page de morceau
+
+- **WHEN** un visiteur consulte une page de morceau
+- **THEN** les règles sont évaluées avec, en contexte, l'artiste, le titre du morceau et
+  le contributeur
+
+#### Scenario: Évaluation sur une page de liste
+
+- **WHEN** un visiteur consulte une liste de morceaux
+- **THEN** les règles sont évaluées avec, en contexte, les termes de recherche et le
+  contributeur demandés
+
+#### Scenario: Paramètres de la requête pris en compte
+
+- **THEN** les paramètres de la requête sont joints au contexte d'évaluation, ce qui
+  permet de déclencher un désastre par l'URL
+
+#### Scenario: Aucune règle satisfaite
+
+- **WHEN** aucune règle ne correspond
+- **THEN** la page est servie sans altération
+
+### Requirement: Part d'aléatoire
+
+Une règle SHALL pouvoir ne se déclencher qu'une fois sur plusieurs, afin que deux
+consultations de la même page ne produisent pas nécessairement le même effet.
+
+#### Scenario: Règle probabiliste
+
+- **WHEN** une règle déclare une probabilité inférieure à 1
+- **THEN** elle ne se déclenche qu'une partie du temps, pour un même contexte
+
+#### Scenario: Règle certaine
+
+- **WHEN** une règle déclare une probabilité de 1
+- **THEN** elle se déclenche à chaque fois que son expression est satisfaite
+
+### Requirement: Application d'une recette
+
+L'application d'une recette SHALL enrichir la réponse des ressources du désastre
+correspondant, sans modifier le contenu servi.
+
+#### Scenario: Ressources du désastre
+
+- **WHEN** une recette est appliquée
+- **THEN** les feuilles de style du désastre correspondant sont ajoutées à la réponse
+- **AND** ses scripts sont ajoutés à la réponse
+
+#### Scenario: Scripts externes déclarés
+
+- **WHEN** la recette déclare des scripts externes
+- **THEN** ces scripts sont ajoutés à la réponse en plus des ressources du désastre
+
+#### Scenario: Options transmises au désastre
+
+- **WHEN** la recette déclare des options
+- **THEN** ces options sont mises à disposition du désastre côté client
+
+#### Scenario: Recette désactivée
+
+- **WHEN** une recette est marquée comme désactivée en configuration
+- **THEN** elle n'est jamais appliquée
+
+### Requirement: Cumul des désastres
+
+Plusieurs désastres SHALL pouvoir s'appliquer à une même page.
+
+#### Scenario: Règles multiples satisfaites
+
+- **WHEN** plusieurs règles se déclenchent pour un même affichage
+- **THEN** les recettes de chacune sont appliquées à la réponse
+
+### Requirement: Absence de configuration
+
+Le système SHALL servir les pages normalement lorsque la configuration des désastres est
+absente.
+
+#### Scenario: Fichier de configuration manquant
+
+- **WHEN** le fichier de configuration des désastres n'existe pas
+- **THEN** aucune altération n'est appliquée et la page est servie normalement

--- a/openspec/changes/specifier-contrat-public-existant/specs/desastres/spec.md
+++ b/openspec/changes/specifier-contrat-public-existant/specs/desastres/spec.md
@@ -11,84 +11,85 @@ consulté. C'est un parti pris éditorial du site, pas un défaut.
 Le système SHALL évaluer, à chaque affichage d'une page de morceau ou de liste, un jeu de
 règles déclarées en configuration, et SHALL appliquer les recettes des règles retenues.
 
-#### Scenario: Évaluation sur une page de morceau
+#### Scénario : Évaluation sur une page de morceau
 
-- **WHEN** un visiteur consulte une page de morceau
-- **THEN** les règles sont évaluées avec, en contexte, l'artiste, le titre du morceau et
+- **QUAND** un visiteur consulte une page de morceau
+- **ALORS** les règles sont évaluées avec, en contexte, l'artiste, le titre du morceau et
   le contributeur
 
-#### Scenario: Évaluation sur une page de liste
+#### Scénario : Évaluation sur une page de liste
 
-- **WHEN** un visiteur consulte une liste de morceaux
-- **THEN** les règles sont évaluées avec, en contexte, les termes de recherche et le
+- **QUAND** un visiteur consulte une liste de morceaux
+- **ALORS** les règles sont évaluées avec, en contexte, les termes de recherche et le
   contributeur demandés
 
-#### Scenario: Paramètres de la requête pris en compte
+#### Scénario : Paramètres de la requête pris en compte
 
-- **THEN** les paramètres de la requête sont joints au contexte d'évaluation, ce qui
+- **QUAND** les règles sont évaluées pour un affichage
+- **ALORS** les paramètres de la requête sont joints au contexte d'évaluation, ce qui
   permet de déclencher un désastre par l'URL
 
-#### Scenario: Aucune règle satisfaite
+#### Scénario : Aucune règle satisfaite
 
-- **WHEN** aucune règle ne correspond
-- **THEN** la page est servie sans altération
+- **QUAND** aucune règle ne correspond
+- **ALORS** la page est servie sans altération
 
 ### Requirement: Part d'aléatoire
 
 Une règle SHALL pouvoir ne se déclencher qu'une fois sur plusieurs, afin que deux
 consultations de la même page ne produisent pas nécessairement le même effet.
 
-#### Scenario: Règle probabiliste
+#### Scénario : Règle probabiliste
 
-- **WHEN** une règle déclare une probabilité inférieure à 1
-- **THEN** elle ne se déclenche qu'une partie du temps, pour un même contexte
+- **QUAND** une règle déclare une probabilité inférieure à 1
+- **ALORS** elle ne se déclenche qu'une partie du temps, pour un même contexte
 
-#### Scenario: Règle certaine
+#### Scénario : Règle certaine
 
-- **WHEN** une règle déclare une probabilité de 1
-- **THEN** elle se déclenche à chaque fois que son expression est satisfaite
+- **QUAND** une règle déclare une probabilité de 1
+- **ALORS** elle se déclenche à chaque fois que son expression est satisfaite
 
 ### Requirement: Application d'une recette
 
 L'application d'une recette SHALL enrichir la réponse des ressources du désastre
 correspondant, sans modifier le contenu servi.
 
-#### Scenario: Ressources du désastre
+#### Scénario : Ressources du désastre
 
-- **WHEN** une recette est appliquée
-- **THEN** les feuilles de style du désastre correspondant sont ajoutées à la réponse
-- **AND** ses scripts sont ajoutés à la réponse
+- **QUAND** une recette est appliquée
+- **ALORS** les feuilles de style du désastre correspondant sont ajoutées à la réponse
+- **ET** ses scripts sont ajoutés à la réponse
 
-#### Scenario: Scripts externes déclarés
+#### Scénario : Scripts externes déclarés
 
-- **WHEN** la recette déclare des scripts externes
-- **THEN** ces scripts sont ajoutés à la réponse en plus des ressources du désastre
+- **QUAND** la recette déclare des scripts externes
+- **ALORS** ces scripts sont ajoutés à la réponse en plus des ressources du désastre
 
-#### Scenario: Options transmises au désastre
+#### Scénario : Options transmises au désastre
 
-- **WHEN** la recette déclare des options
-- **THEN** ces options sont mises à disposition du désastre côté client
+- **QUAND** la recette déclare des options
+- **ALORS** ces options sont mises à disposition du désastre côté client
 
-#### Scenario: Recette désactivée
+#### Scénario : Recette désactivée
 
-- **WHEN** une recette est marquée comme désactivée en configuration
-- **THEN** elle n'est jamais appliquée
+- **QUAND** une recette est marquée comme désactivée en configuration
+- **ALORS** elle n'est jamais appliquée
 
 ### Requirement: Cumul des désastres
 
 Plusieurs désastres SHALL pouvoir s'appliquer à une même page.
 
-#### Scenario: Règles multiples satisfaites
+#### Scénario : Règles multiples satisfaites
 
-- **WHEN** plusieurs règles se déclenchent pour un même affichage
-- **THEN** les recettes de chacune sont appliquées à la réponse
+- **QUAND** plusieurs règles se déclenchent pour un même affichage
+- **ALORS** les recettes de chacune sont appliquées à la réponse
 
 ### Requirement: Absence de configuration
 
 Le système SHALL servir les pages normalement lorsque la configuration des désastres est
 absente.
 
-#### Scenario: Fichier de configuration manquant
+#### Scénario : Fichier de configuration manquant
 
-- **WHEN** le fichier de configuration des désastres n'existe pas
-- **THEN** aucune altération n'est appliquée et la page est servie normalement
+- **QUAND** le fichier de configuration des désastres n'existe pas
+- **ALORS** aucune altération n'est appliquée et la page est servie normalement

--- a/openspec/changes/specifier-contrat-public-existant/specs/embarquement-oembed/spec.md
+++ b/openspec/changes/specifier-contrat-public-existant/specs/embarquement-oembed/spec.md
@@ -1,0 +1,100 @@
+## Purpose
+
+Décrit comment un site tiers obtient un lecteur embarquable pour un morceau, par le
+protocole oEmbed ou en pointant directement le gabarit d'embarquement.
+
+## ADDED Requirements
+
+### Requirement: Point d'entrée oEmbed
+
+Le système SHALL répondre aux demandes oEmbed portant sur l'adresse d'un morceau
+publiable.
+
+#### Scenario: Demande sur un morceau publiable
+
+- **WHEN** un consommateur demande `/oembed` avec le paramètre `url` valant l'adresse
+  d'un morceau publiable
+- **THEN** une réponse oEmbed décrivant ce morceau est servie
+
+#### Scenario: Morceau inconnu
+
+- **WHEN** l'adresse fournie ne désigne aucun morceau publiable
+- **THEN** la réponse est une erreur 404
+
+#### Scenario: Résolution du morceau depuis l'adresse
+
+- **WHEN** l'adresse fournie comporte un chemin
+- **THEN** le morceau est résolu à partir du dernier segment de ce chemin, les segments
+  précédents étant ignorés
+
+### Requirement: Contenu de la réponse oEmbed
+
+La réponse oEmbed SHALL être de type `rich` et SHALL porter un fragment HTML prêt à être
+inséré par le consommateur.
+
+#### Scenario: Champs de la réponse
+
+- **WHEN** une réponse oEmbed est servie
+- **THEN** elle porte `version` valant 1 et `type` valant `rich`
+- **AND** elle porte `provider_name` et `provider_url` identifiant le site
+- **AND** elle porte `title` valant « artiste - titre »
+- **AND** elle porte `description` valant le corps du post débarrassé de son balisage
+- **AND** elle porte `width` et `height` correspondant aux dimensions du gabarit
+  d'embarquement effectivement servi
+
+#### Scenario: Fragment embarquable
+
+- **THEN** le champ `html` contient un élément `iframe` sans bordure ni défilement
+- **AND** l'adresse source de cet `iframe` est celle de la page du morceau assortie du
+  paramètre `embed`
+- **AND** ses dimensions sont celles déclarées par `width` et `height`
+
+### Requirement: Négociation du format oEmbed
+
+La réponse oEmbed SHALL être servie en JSON par défaut, et en XML sur demande explicite.
+
+#### Scenario: Format JSON par défaut
+
+- **WHEN** aucun paramètre `format` n'est fourni, ou qu'il vaut `json`
+- **THEN** la réponse est un objet JSON
+- **AND** le type de contenu est `application/json`
+
+#### Scenario: Format XML
+
+- **WHEN** le paramètre `format` vaut `xml`
+- **THEN** la réponse est un document XML dont la racine est `oembed`
+- **AND** chaque champ devient un élément enfant, son contenu étant échappé
+- **AND** le type de contenu est `text/xml+oembed`
+
+#### Scenario: Format inconnu
+
+- **WHEN** le paramètre `format` vaut autre chose que `json` ou `xml`
+- **THEN** aucune donnée n'est encodée et la réponse est inexploitable
+
+> Comportement constaté, non souhaitable : ni erreur, ni repli sur le format par défaut.
+> Le type de contenu `application/json+oembed` attendu par la spécification oEmbed n'est
+> par ailleurs pas déclaré. À traiter par un changement dédié.
+
+### Requirement: Gabarit d'embarquement
+
+Le système SHALL servir, pour un morceau publiable, un document autonome contenant un
+lecteur audio et les liens de retour vers le site.
+
+#### Scenario: Demande du gabarit
+
+- **WHEN** un visiteur demande `/post/:slug` avec le paramètre `embed`
+- **THEN** un document autonome est servi, sans l'habillage du site
+
+#### Scenario: Contenu du gabarit
+
+- **THEN** le document porte le titre du morceau, lié à sa page, ouvrant dans un nouvel
+  onglet
+- **AND** il porte le corps du post rendu depuis son Markdown
+- **AND** il porte un lecteur audio HTML avec ses contrôles, dont la source est le
+  fichier audio du morceau
+- **AND** il mentionne le contributeur, lié à sa playlist, et le site
+
+#### Scenario: Variante d'embarquement
+
+- **WHEN** le paramètre `embed` porte une valeur
+- **THEN** le gabarit correspondant à cette variante est servi si il existe

--- a/openspec/changes/specifier-contrat-public-existant/specs/embarquement-oembed/spec.md
+++ b/openspec/changes/specifier-contrat-public-existant/specs/embarquement-oembed/spec.md
@@ -10,21 +10,21 @@ protocole oEmbed ou en pointant directement le gabarit d'embarquement.
 Le système SHALL répondre aux demandes oEmbed portant sur l'adresse d'un morceau
 publiable.
 
-#### Scenario: Demande sur un morceau publiable
+#### Scénario : Demande sur un morceau publiable
 
-- **WHEN** un consommateur demande `/oembed` avec le paramètre `url` valant l'adresse
+- **QUAND** un consommateur demande `/oembed` avec le paramètre `url` valant l'adresse
   d'un morceau publiable
-- **THEN** une réponse oEmbed décrivant ce morceau est servie
+- **ALORS** une réponse oEmbed décrivant ce morceau est servie
 
-#### Scenario: Morceau inconnu
+#### Scénario : Morceau inconnu
 
-- **WHEN** l'adresse fournie ne désigne aucun morceau publiable
-- **THEN** la réponse est une erreur 404
+- **QUAND** l'adresse fournie ne désigne aucun morceau publiable
+- **ALORS** la réponse est une erreur 404
 
-#### Scenario: Résolution du morceau depuis l'adresse
+#### Scénario : Résolution du morceau depuis l'adresse
 
-- **WHEN** l'adresse fournie comporte un chemin
-- **THEN** le morceau est résolu à partir du dernier segment de ce chemin, les segments
+- **QUAND** l'adresse fournie comporte un chemin
+- **ALORS** le morceau est résolu à partir du dernier segment de ce chemin, les segments
   précédents étant ignorés
 
 ### Requirement: Contenu de la réponse oEmbed
@@ -32,44 +32,45 @@ publiable.
 La réponse oEmbed SHALL être de type `rich` et SHALL porter un fragment HTML prêt à être
 inséré par le consommateur.
 
-#### Scenario: Champs de la réponse
+#### Scénario : Champs de la réponse
 
-- **WHEN** une réponse oEmbed est servie
-- **THEN** elle porte `version` valant 1 et `type` valant `rich`
-- **AND** elle porte `provider_name` et `provider_url` identifiant le site
-- **AND** elle porte `title` valant « artiste - titre »
-- **AND** elle porte `description` valant le corps du post débarrassé de son balisage
-- **AND** elle porte `width` et `height` correspondant aux dimensions du gabarit
+- **QUAND** une réponse oEmbed est servie
+- **ALORS** elle porte `version` valant 1 et `type` valant `rich`
+- **ET** elle porte `provider_name` et `provider_url` identifiant le site
+- **ET** elle porte `title` valant « artiste - titre »
+- **ET** elle porte `description` valant le corps du post débarrassé de son balisage
+- **ET** elle porte `width` et `height` correspondant aux dimensions du gabarit
   d'embarquement effectivement servi
 
-#### Scenario: Fragment embarquable
+#### Scénario : Fragment embarquable
 
-- **THEN** le champ `html` contient un élément `iframe` sans bordure ni défilement
-- **AND** l'adresse source de cet `iframe` est celle de la page du morceau assortie du
+- **QUAND** une réponse oEmbed est servie
+- **ALORS** le champ `html` contient un élément `iframe` sans bordure ni défilement
+- **ET** l'adresse source de cet `iframe` est celle de la page du morceau assortie du
   paramètre `embed`
-- **AND** ses dimensions sont celles déclarées par `width` et `height`
+- **ET** ses dimensions sont celles déclarées par `width` et `height`
 
 ### Requirement: Négociation du format oEmbed
 
 La réponse oEmbed SHALL être servie en JSON par défaut, et en XML sur demande explicite.
 
-#### Scenario: Format JSON par défaut
+#### Scénario : Format JSON par défaut
 
-- **WHEN** aucun paramètre `format` n'est fourni, ou qu'il vaut `json`
-- **THEN** la réponse est un objet JSON
-- **AND** le type de contenu est `application/json`
+- **QUAND** aucun paramètre `format` n'est fourni, ou qu'il vaut `json`
+- **ALORS** la réponse est un objet JSON
+- **ET** le type de contenu est `application/json`
 
-#### Scenario: Format XML
+#### Scénario : Format XML
 
-- **WHEN** le paramètre `format` vaut `xml`
-- **THEN** la réponse est un document XML dont la racine est `oembed`
-- **AND** chaque champ devient un élément enfant, son contenu étant échappé
-- **AND** le type de contenu est `text/xml+oembed`
+- **QUAND** le paramètre `format` vaut `xml`
+- **ALORS** la réponse est un document XML dont la racine est `oembed`
+- **ET** chaque champ devient un élément enfant, son contenu étant échappé
+- **ET** le type de contenu est `text/xml+oembed`
 
-#### Scenario: Format inconnu
+#### Scénario : Format inconnu
 
-- **WHEN** le paramètre `format` vaut autre chose que `json` ou `xml`
-- **THEN** aucune donnée n'est encodée et la réponse est inexploitable
+- **QUAND** le paramètre `format` vaut autre chose que `json` ou `xml`
+- **ALORS** aucune donnée n'est encodée et la réponse est inexploitable
 
 > Comportement constaté, non souhaitable : ni erreur, ni repli sur le format par défaut.
 > Le type de contenu `application/json+oembed` attendu par la spécification oEmbed n'est
@@ -80,21 +81,22 @@ La réponse oEmbed SHALL être servie en JSON par défaut, et en XML sur demande
 Le système SHALL servir, pour un morceau publiable, un document autonome contenant un
 lecteur audio et les liens de retour vers le site.
 
-#### Scenario: Demande du gabarit
+#### Scénario : Demande du gabarit
 
-- **WHEN** un visiteur demande `/post/:slug` avec le paramètre `embed`
-- **THEN** un document autonome est servi, sans l'habillage du site
+- **QUAND** un visiteur demande `/post/:slug` avec le paramètre `embed`
+- **ALORS** un document autonome est servi, sans l'habillage du site
 
-#### Scenario: Contenu du gabarit
+#### Scénario : Contenu du gabarit
 
-- **THEN** le document porte le titre du morceau, lié à sa page, ouvrant dans un nouvel
+- **QUAND** le gabarit d'embarquement d'un morceau est servi
+- **ALORS** le document porte le titre du morceau, lié à sa page, ouvrant dans un nouvel
   onglet
-- **AND** il porte le corps du post rendu depuis son Markdown
-- **AND** il porte un lecteur audio HTML avec ses contrôles, dont la source est le
+- **ET** il porte le corps du post rendu depuis son Markdown
+- **ET** il porte un lecteur audio HTML avec ses contrôles, dont la source est le
   fichier audio du morceau
-- **AND** il mentionne le contributeur, lié à sa playlist, et le site
+- **ET** il mentionne le contributeur, lié à sa playlist, et le site
 
-#### Scenario: Variante d'embarquement
+#### Scénario : Variante d'embarquement
 
-- **WHEN** le paramètre `embed` porte une valeur
-- **THEN** le gabarit correspondant à cette variante est servi si il existe
+- **QUAND** le paramètre `embed` porte une valeur
+- **ALORS** le gabarit correspondant à cette variante est servi si il existe

--- a/openspec/changes/specifier-contrat-public-existant/specs/flux-syndication/spec.md
+++ b/openspec/changes/specifier-contrat-public-existant/specs/flux-syndication/spec.md
@@ -1,0 +1,80 @@
+## Purpose
+
+Décrit le flux de syndication publié par le site, son contenu, ses filtres et les
+attentes des agrégateurs et lecteurs de podcast qui le consomment.
+
+## ADDED Requirements
+
+### Requirement: Publication du flux
+
+Le système SHALL publier un flux RSS 2.01 en français décrivant les morceaux publiables.
+
+#### Scenario: Accès au flux
+
+- **WHEN** un consommateur demande `/posts/feed`
+- **THEN** un document RSS 2.01 est servi
+- **AND** la langue déclarée est le français
+- **AND** le flux porte le titre du site, son adresse et sa description
+
+#### Scenario: Illustration du flux
+
+- **THEN** le flux déclare une favicône et une image de logo servies par le site
+- **AND** l'image et le titre de l'illustration renvoient à l'adresse du site
+
+### Requirement: Volume et filtrage du flux
+
+Le flux SHALL contenir au plus cinquante morceaux par défaut, et SHALL pouvoir être
+restreint à un contributeur ou à un nombre d'items choisi.
+
+#### Scenario: Volume par défaut
+
+- **WHEN** aucun paramètre de volume n'est fourni
+- **THEN** le flux contient au plus les cinquante morceaux publiables les plus récents
+
+#### Scenario: Volume choisi
+
+- **WHEN** le paramètre `count` accompagne la demande
+- **THEN** le flux contient au plus ce nombre de morceaux
+
+#### Scenario: Flux d'un contributeur
+
+- **WHEN** le paramètre `contributor` accompagne la demande
+- **THEN** le flux ne contient que les morceaux de ce contributeur
+
+### Requirement: Contenu d'un item
+
+Chaque item du flux SHALL identifier le morceau, dater sa publication et permettre son
+écoute directe.
+
+#### Scenario: Identification de l'item
+
+- **WHEN** un morceau figure dans le flux
+- **THEN** le titre de l'item vaut « artiste - titre »
+- **AND** l'item renvoie à la page du morceau
+- **AND** l'auteur de l'item est le nom d'affichage du contributeur
+- **AND** l'identifiant unique de l'item est l'identifiant d'URL du morceau
+- **AND** la date de publication de l'item est la date de publication du morceau
+
+#### Scenario: Description de l'item
+
+- **THEN** la description contient une illustration cliquable renvoyant à la page du
+  morceau
+- **AND** elle contient le corps du post rendu depuis son Markdown
+- **AND** elle mentionne le contributeur
+
+#### Scenario: Illustration glitchée
+
+- **WHEN** l'effet de glitch du logo est actif pour cet item
+- **THEN** l'illustration de la description est produite par le service de glitch, avec
+  l'identifiant du morceau comme graine
+
+#### Scenario: Fichier joint pour l'écoute
+
+- **THEN** l'item porte une pièce jointe désignant l'adresse absolue du fichier audio
+- **AND** le type déclaré de la pièce jointe est `audio/mpeg`
+- **AND** la taille déclarée est celle du fichier, ou zéro lorsque le fichier n'est pas
+  lisible sur le serveur
+
+> Comportement constaté, non souhaitable : la taille de la pièce jointe est obtenue en
+> chargeant l'intégralité de chaque fichier audio en mémoire, pour chaque item et à
+> chaque demande du flux. À traiter par un changement dédié.

--- a/openspec/changes/specifier-contrat-public-existant/specs/flux-syndication/spec.md
+++ b/openspec/changes/specifier-contrat-public-existant/specs/flux-syndication/spec.md
@@ -9,70 +9,73 @@ attentes des agrégateurs et lecteurs de podcast qui le consomment.
 
 Le système SHALL publier un flux RSS 2.01 en français décrivant les morceaux publiables.
 
-#### Scenario: Accès au flux
+#### Scénario : Accès au flux
 
-- **WHEN** un consommateur demande `/posts/feed`
-- **THEN** un document RSS 2.01 est servi
-- **AND** la langue déclarée est le français
-- **AND** le flux porte le titre du site, son adresse et sa description
+- **QUAND** un consommateur demande `/posts/feed`
+- **ALORS** un document RSS 2.01 est servi
+- **ET** la langue déclarée est le français
+- **ET** le flux porte le titre du site, son adresse et sa description
 
-#### Scenario: Illustration du flux
+#### Scénario : Illustration du flux
 
-- **THEN** le flux déclare une favicône et une image de logo servies par le site
-- **AND** l'image et le titre de l'illustration renvoient à l'adresse du site
+- **QUAND** un consommateur demande `/posts/feed`
+- **ALORS** le flux déclare une favicône et une image de logo servies par le site
+- **ET** l'image et le titre de l'illustration renvoient à l'adresse du site
 
 ### Requirement: Volume et filtrage du flux
 
 Le flux SHALL contenir au plus cinquante morceaux par défaut, et SHALL pouvoir être
 restreint à un contributeur ou à un nombre d'items choisi.
 
-#### Scenario: Volume par défaut
+#### Scénario : Volume par défaut
 
-- **WHEN** aucun paramètre de volume n'est fourni
-- **THEN** le flux contient au plus les cinquante morceaux publiables les plus récents
+- **QUAND** aucun paramètre de volume n'est fourni
+- **ALORS** le flux contient au plus les cinquante morceaux publiables les plus récents
 
-#### Scenario: Volume choisi
+#### Scénario : Volume choisi
 
-- **WHEN** le paramètre `count` accompagne la demande
-- **THEN** le flux contient au plus ce nombre de morceaux
+- **QUAND** le paramètre `count` accompagne la demande
+- **ALORS** le flux contient au plus ce nombre de morceaux
 
-#### Scenario: Flux d'un contributeur
+#### Scénario : Flux d'un contributeur
 
-- **WHEN** le paramètre `contributor` accompagne la demande
-- **THEN** le flux ne contient que les morceaux de ce contributeur
+- **QUAND** le paramètre `contributor` accompagne la demande
+- **ALORS** le flux ne contient que les morceaux de ce contributeur
 
 ### Requirement: Contenu d'un item
 
 Chaque item du flux SHALL identifier le morceau, dater sa publication et permettre son
 écoute directe.
 
-#### Scenario: Identification de l'item
+#### Scénario : Identification de l'item
 
-- **WHEN** un morceau figure dans le flux
-- **THEN** le titre de l'item vaut « artiste - titre »
-- **AND** l'item renvoie à la page du morceau
-- **AND** l'auteur de l'item est le nom d'affichage du contributeur
-- **AND** l'identifiant unique de l'item est l'identifiant d'URL du morceau
-- **AND** la date de publication de l'item est la date de publication du morceau
+- **QUAND** un morceau figure dans le flux
+- **ALORS** le titre de l'item vaut « artiste - titre »
+- **ET** l'item renvoie à la page du morceau
+- **ET** l'auteur de l'item est le nom d'affichage du contributeur
+- **ET** l'identifiant unique de l'item est l'identifiant d'URL du morceau
+- **ET** la date de publication de l'item est la date de publication du morceau
 
-#### Scenario: Description de l'item
+#### Scénario : Description de l'item
 
-- **THEN** la description contient une illustration cliquable renvoyant à la page du
+- **QUAND** un morceau figure dans le flux
+- **ALORS** la description contient une illustration cliquable renvoyant à la page du
   morceau
-- **AND** elle contient le corps du post rendu depuis son Markdown
-- **AND** elle mentionne le contributeur
+- **ET** elle contient le corps du post rendu depuis son Markdown
+- **ET** elle mentionne le contributeur
 
-#### Scenario: Illustration glitchée
+#### Scénario : Illustration glitchée
 
-- **WHEN** l'effet de glitch du logo est actif pour cet item
-- **THEN** l'illustration de la description est produite par le service de glitch, avec
+- **QUAND** l'effet de glitch du logo est actif pour cet item
+- **ALORS** l'illustration de la description est produite par le service de glitch, avec
   l'identifiant du morceau comme graine
 
-#### Scenario: Fichier joint pour l'écoute
+#### Scénario : Fichier joint pour l'écoute
 
-- **THEN** l'item porte une pièce jointe désignant l'adresse absolue du fichier audio
-- **AND** le type déclaré de la pièce jointe est `audio/mpeg`
-- **AND** la taille déclarée est celle du fichier, ou zéro lorsque le fichier n'est pas
+- **QUAND** un morceau figure dans le flux
+- **ALORS** l'item porte une pièce jointe désignant l'adresse absolue du fichier audio
+- **ET** le type déclaré de la pièce jointe est `audio/mpeg`
+- **ET** la taille déclarée est celle du fichier, ou zéro lorsque le fichier n'est pas
   lisible sur le serveur
 
 > Comportement constaté, non souhaitable : la taille de la pièce jointe est obtenue en

--- a/openspec/changes/specifier-contrat-public-existant/specs/formats-de-sortie/spec.md
+++ b/openspec/changes/specifier-contrat-public-existant/specs/formats-de-sortie/spec.md
@@ -1,0 +1,117 @@
+## Purpose
+
+Décrit les représentations alternatives d'un morceau ou d'une liste de morceaux, et la
+manière dont un consommateur les demande.
+
+## ADDED Requirements
+
+### Requirement: Sélection du format
+
+Le système SHALL servir une représentation alternative lorsque le paramètre `format`
+désigne un format connu, et SHALL déclarer le type de contenu correspondant.
+
+#### Scenario: Formats reconnus
+
+- **WHEN** un consommateur ajoute `format=json`, `format=xspf` ou `format=max` à une
+  demande de morceau ou de liste
+- **THEN** la réponse est servie sans gabarit d'habillage
+- **AND** le type de contenu est respectivement `application/json`,
+  `application/xspf+xml` ou `application/maxmsp+text`
+
+#### Scenario: Format inconnu
+
+- **WHEN** le paramètre `format` désigne une valeur non reconnue
+- **THEN** la page est servie dans sa représentation HTML habituelle
+
+#### Scenario: Formats annoncés au visiteur
+
+- **WHEN** une page de morceau ou de liste est servie en HTML
+- **THEN** les formats `json` et `xspf` sont annoncés au visiteur
+- **AND** le format `max` ne l'est pas, bien qu'il reste accessible
+
+### Requirement: Représentation JSON d'un morceau
+
+La représentation JSON d'un morceau SHALL suivre la convention jsonapi.org fondée sur les
+URL, et SHALL exposer le morceau, sa piste, son contributeur et ses liens de navigation.
+
+#### Scenario: Identité et adresse
+
+- **WHEN** un consommateur demande la représentation JSON d'un morceau
+- **THEN** le champ `id` vaut l'identifiant d'URL du morceau
+- **AND** le champ `href` vaut l'adresse absolue de sa représentation JSON
+
+#### Scenario: Corps du morceau
+
+- **THEN** le champ `body` est un objet portant `markdown`, le texte source, et `html`,
+  son rendu
+
+#### Scenario: Description de la piste
+
+- **THEN** le champ `track` est un objet portant `href` (adresse absolue du fichier
+  audio), `title`, `author` et `md5`
+- **AND** les champs bruts correspondants n'apparaissent pas à la racine de l'objet
+
+#### Scenario: Description du contributeur
+
+- **THEN** le champ `contributor` est un objet portant `name`, `slug` et `href_website`
+
+#### Scenario: Liens de navigation
+
+- **THEN** le champ `links` porte `contributor_playlist`, adresse de la liste JSON des
+  morceaux du contributeur
+- **AND** `links` porte `avatar`, adresse de l'illustration associée au morceau
+- **AND** `links` porte `post_previous` et `post_next` lorsque ces morceaux sont connus
+  de l'appelant
+
+#### Scenario: Champs jamais exposés
+
+- **THEN** les champs internes de mise en ligne, de révision et l'objet utilisateur
+  complet sont absents de la réponse
+
+### Requirement: Représentation XSPF d'une liste
+
+La représentation XSPF d'une liste SHALL être une playlist valide, encodée en UTF-8,
+dont chaque piste porte son adresse de lecture directe.
+
+#### Scenario: Structure de la playlist
+
+- **WHEN** un consommateur demande une liste au format `xspf`
+- **THEN** la réponse est un document XSPF déclarant l'encodage UTF-8
+- **AND** chaque piste porte le créateur, le titre, le corps du post en annotation,
+  l'adresse de la page du morceau en information, et l'adresse absolue du fichier audio
+  en localisation
+
+#### Scenario: Titre de la playlist selon le filtre
+
+- **WHEN** la liste est filtrée par contributeur
+- **THEN** le titre de la playlist mentionne le nom d'affichage de ce contributeur
+- **AND** lorsque la liste résulte d'une recherche, le titre mentionne les termes
+  recherchés
+- **AND** en l'absence de filtre, le titre annonce l'ensemble des morceaux
+
+### Requirement: Représentation Max/MSP d'une liste
+
+La représentation `max` d'une liste SHALL être une suite de lignes textuelles, une par
+morceau, dont les champs sont débarrassés des caractères qui casseraient l'analyse côté
+Max/MSP.
+
+#### Scenario: Ligne par morceau
+
+- **WHEN** un consommateur demande une liste au format `max`
+- **THEN** chaque morceau produit une ligne portant son rang, l'artiste, le titre,
+  l'adresse du fichier audio, l'adresse de la page, le contributeur, le nombre total de
+  morceaux et le corps du post
+- **AND** les guillemets et retours à la ligne sont retirés des champs textuels
+
+### Requirement: Représentation Max/MSP d'un morceau isolé
+
+Le format `max` appliqué à un morceau isolé SHALL être considéré comme non implémenté.
+
+#### Scenario: Demande du format max sur un morceau
+
+- **WHEN** un consommateur demande `/post/:slug` au format `max`
+- **THEN** la réponse ne contient aucune donnée exploitable
+
+> Comportement constaté, non souhaitable : le gabarit correspondant ne contient que la
+> mention `TODO`, alors que le format est annoncé comme disponible par la sélection de
+> format. À traiter par un changement dédié.

--- a/openspec/changes/specifier-contrat-public-existant/specs/formats-de-sortie/spec.md
+++ b/openspec/changes/specifier-contrat-public-existant/specs/formats-de-sortie/spec.md
@@ -10,62 +10,67 @@ manière dont un consommateur les demande.
 Le système SHALL servir une représentation alternative lorsque le paramètre `format`
 désigne un format connu, et SHALL déclarer le type de contenu correspondant.
 
-#### Scenario: Formats reconnus
+#### Scénario : Formats reconnus
 
-- **WHEN** un consommateur ajoute `format=json`, `format=xspf` ou `format=max` à une
+- **QUAND** un consommateur ajoute `format=json`, `format=xspf` ou `format=max` à une
   demande de morceau ou de liste
-- **THEN** la réponse est servie sans gabarit d'habillage
-- **AND** le type de contenu est respectivement `application/json`,
+- **ALORS** la réponse est servie sans gabarit d'habillage
+- **ET** le type de contenu est respectivement `application/json`,
   `application/xspf+xml` ou `application/maxmsp+text`
 
-#### Scenario: Format inconnu
+#### Scénario : Format inconnu
 
-- **WHEN** le paramètre `format` désigne une valeur non reconnue
-- **THEN** la page est servie dans sa représentation HTML habituelle
+- **QUAND** le paramètre `format` désigne une valeur non reconnue
+- **ALORS** la page est servie dans sa représentation HTML habituelle
 
-#### Scenario: Formats annoncés au visiteur
+#### Scénario : Formats annoncés au visiteur
 
-- **WHEN** une page de morceau ou de liste est servie en HTML
-- **THEN** les formats `json` et `xspf` sont annoncés au visiteur
-- **AND** le format `max` ne l'est pas, bien qu'il reste accessible
+- **QUAND** une page de morceau ou de liste est servie en HTML
+- **ALORS** les formats `json` et `xspf` sont annoncés au visiteur
+- **ET** le format `max` ne l'est pas, bien qu'il reste accessible
 
 ### Requirement: Représentation JSON d'un morceau
 
 La représentation JSON d'un morceau SHALL suivre la convention jsonapi.org fondée sur les
 URL, et SHALL exposer le morceau, sa piste, son contributeur et ses liens de navigation.
 
-#### Scenario: Identité et adresse
+#### Scénario : Identité et adresse
 
-- **WHEN** un consommateur demande la représentation JSON d'un morceau
-- **THEN** le champ `id` vaut l'identifiant d'URL du morceau
-- **AND** le champ `href` vaut l'adresse absolue de sa représentation JSON
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** le champ `id` vaut l'identifiant d'URL du morceau
+- **ET** le champ `href` vaut l'adresse absolue de sa représentation JSON
 
-#### Scenario: Corps du morceau
+#### Scénario : Corps du morceau
 
-- **THEN** le champ `body` est un objet portant `markdown`, le texte source, et `html`,
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** le champ `body` est un objet portant `markdown`, le texte source, et `html`,
   son rendu
 
-#### Scenario: Description de la piste
+#### Scénario : Description de la piste
 
-- **THEN** le champ `track` est un objet portant `href` (adresse absolue du fichier
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** le champ `track` est un objet portant `href` (adresse absolue du fichier
   audio), `title`, `author` et `md5`
-- **AND** les champs bruts correspondants n'apparaissent pas à la racine de l'objet
+- **ET** les champs bruts correspondants n'apparaissent pas à la racine de l'objet
 
-#### Scenario: Description du contributeur
+#### Scénario : Description du contributeur
 
-- **THEN** le champ `contributor` est un objet portant `name`, `slug` et `href_website`
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** le champ `contributor` est un objet portant `name`, `slug` et `href_website`
 
-#### Scenario: Liens de navigation
+#### Scénario : Liens de navigation
 
-- **THEN** le champ `links` porte `contributor_playlist`, adresse de la liste JSON des
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** le champ `links` porte `contributor_playlist`, adresse de la liste JSON des
   morceaux du contributeur
-- **AND** `links` porte `avatar`, adresse de l'illustration associée au morceau
-- **AND** `links` porte `post_previous` et `post_next` lorsque ces morceaux sont connus
+- **ET** `links` porte `avatar`, adresse de l'illustration associée au morceau
+- **ET** `links` porte `post_previous` et `post_next` lorsque ces morceaux sont connus
   de l'appelant
 
-#### Scenario: Champs jamais exposés
+#### Scénario : Champs jamais exposés
 
-- **THEN** les champs internes de mise en ligne, de révision et l'objet utilisateur
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** les champs internes de mise en ligne, de révision et l'objet utilisateur
   complet sont absents de la réponse
 
 ### Requirement: Représentation XSPF d'une liste
@@ -73,21 +78,21 @@ URL, et SHALL exposer le morceau, sa piste, son contributeur et ses liens de nav
 La représentation XSPF d'une liste SHALL être une playlist valide, encodée en UTF-8,
 dont chaque piste porte son adresse de lecture directe.
 
-#### Scenario: Structure de la playlist
+#### Scénario : Structure de la playlist
 
-- **WHEN** un consommateur demande une liste au format `xspf`
-- **THEN** la réponse est un document XSPF déclarant l'encodage UTF-8
-- **AND** chaque piste porte le créateur, le titre, le corps du post en annotation,
+- **QUAND** un consommateur demande une liste au format `xspf`
+- **ALORS** la réponse est un document XSPF déclarant l'encodage UTF-8
+- **ET** chaque piste porte le créateur, le titre, le corps du post en annotation,
   l'adresse de la page du morceau en information, et l'adresse absolue du fichier audio
   en localisation
 
-#### Scenario: Titre de la playlist selon le filtre
+#### Scénario : Titre de la playlist selon le filtre
 
-- **WHEN** la liste est filtrée par contributeur
-- **THEN** le titre de la playlist mentionne le nom d'affichage de ce contributeur
-- **AND** lorsque la liste résulte d'une recherche, le titre mentionne les termes
+- **QUAND** la liste est filtrée par contributeur
+- **ALORS** le titre de la playlist mentionne le nom d'affichage de ce contributeur
+- **ET** lorsque la liste résulte d'une recherche, le titre mentionne les termes
   recherchés
-- **AND** en l'absence de filtre, le titre annonce l'ensemble des morceaux
+- **ET** en l'absence de filtre, le titre annonce l'ensemble des morceaux
 
 ### Requirement: Représentation Max/MSP d'une liste
 
@@ -95,22 +100,22 @@ La représentation `max` d'une liste SHALL être une suite de lignes textuelles,
 morceau, dont les champs sont débarrassés des caractères qui casseraient l'analyse côté
 Max/MSP.
 
-#### Scenario: Ligne par morceau
+#### Scénario : Ligne par morceau
 
-- **WHEN** un consommateur demande une liste au format `max`
-- **THEN** chaque morceau produit une ligne portant son rang, l'artiste, le titre,
+- **QUAND** un consommateur demande une liste au format `max`
+- **ALORS** chaque morceau produit une ligne portant son rang, l'artiste, le titre,
   l'adresse du fichier audio, l'adresse de la page, le contributeur, le nombre total de
   morceaux et le corps du post
-- **AND** les guillemets et retours à la ligne sont retirés des champs textuels
+- **ET** les guillemets et retours à la ligne sont retirés des champs textuels
 
 ### Requirement: Représentation Max/MSP d'un morceau isolé
 
 Le format `max` appliqué à un morceau isolé SHALL être considéré comme non implémenté.
 
-#### Scenario: Demande du format max sur un morceau
+#### Scénario : Demande du format max sur un morceau
 
-- **WHEN** un consommateur demande `/post/:slug` au format `max`
-- **THEN** la réponse ne contient aucune donnée exploitable
+- **QUAND** un consommateur demande `/post/:slug` au format `max`
+- **ALORS** la réponse ne contient aucune donnée exploitable
 
 > Comportement constaté, non souhaitable : le gabarit correspondant ne contient que la
 > mention `TODO`, alors que le format est annoncé comme disponible par la sélection de

--- a/openspec/changes/specifier-contrat-public-existant/tasks.md
+++ b/openspec/changes/specifier-contrat-public-existant/tasks.md
@@ -7,7 +7,7 @@
 - [x] 1.5 Spécifier `desastres` d'après `sfDesastreManager`, `DesastreHelper` et les recettes et règles de `config/desastres/`
 - [x] 1.6 Consigner les défauts constatés dans les specs concernées, sans les corriger
 
-## 2. Vérification des specs contre le code
+## 2. Vérification manuelle des specs contre le code
 
 > Cette section demande un environnement Docker fonctionnel, indisponible lors de la
 > rédaction. Chaque scénario a été écrit d'après le code lu, mais aucun n'a été exercé

--- a/openspec/changes/specifier-contrat-public-existant/tasks.md
+++ b/openspec/changes/specifier-contrat-public-existant/tasks.md
@@ -1,0 +1,29 @@
+## 1. Rédaction des spécifications
+
+- [x] 1.1 Spécifier `catalogue-morceaux` d'après `PostTable.class.php`, `routing.yml` et les actions `home`, `show`, `next`, `prev`, `random`, `md5`, `list`
+- [x] 1.2 Spécifier `formats-de-sortie` d'après `setFormats()`, `Post::toJson()` et les gabarits `*.json.php`, `*.xspf.php`, `*.max.php`
+- [x] 1.3 Spécifier `flux-syndication` d'après `executeFeed()`
+- [x] 1.4 Spécifier `embarquement-oembed` d'après `executeOembed()` et `showEmbed.php`
+- [x] 1.5 Spécifier `desastres` d'après `sfDesastreManager`, `DesastreHelper` et les recettes et règles de `config/desastres/`
+- [x] 1.6 Consigner les défauts constatés dans les specs concernées, sans les corriger
+
+## 2. Vérification des specs contre le code
+
+> Cette section demande un environnement Docker fonctionnel, indisponible lors de la
+> rédaction. Chaque scénario a été écrit d'après le code lu, mais aucun n'a été exercé
+> contre l'application en fonctionnement.
+
+- [ ] 2.1 Vérifier la fenêtre de deux heures sur `publish_on` : un morceau à publication dans une heure est-il bien accessible, à trois heures bien inaccessible
+- [ ] 2.2 Vérifier le comportement de `/posts/next` et `/posts/prev` aux extrémités du catalogue, quand aucun morceau suivant ou précédent n'existe
+- [ ] 2.3 Vérifier la réponse de `/post/md5/:md5sum` pour une empreinte inconnue
+- [ ] 2.4 Vérifier les types de contenu réellement émis pour `format=json`, `format=xspf` et `format=max`
+- [ ] 2.5 Vérifier la résolution du morceau par `/oembed` pour une URL comportant des paramètres de requête ou une barre oblique finale
+- [ ] 2.6 Vérifier qu'un `format` inconnu sur `/oembed` produit bien une réponse vide, et non une erreur
+- [ ] 2.7 Vérifier le déclenchement d'un désastre par paramètre d'URL, et le cumul de plusieurs recettes sur une même page
+- [ ] 2.8 Corriger les scénarios que la vérification contredit — le comportement observé fait foi, pas la lecture du code
+
+## 3. Promotion dans le corpus principal
+
+- [ ] 3.1 Une fois les specs vérifiées, les promouvoir dans `openspec/specs/` avec `openspec sync`
+- [ ] 3.2 Corriger `docs/memory-bank/README.adoc`, qui documente des routes inexistantes (`/random`, `/next`, `/prev`, `/md5/:md5sum`, `/feed.rss`) et un lecteur JW Player abandonné — ou acter que le corpus de specs le remplace sur ce périmètre
+- [ ] 3.3 Ouvrir un changement dédié pour chacun des défauts consignés : gabarit `max` d'un morceau isolé, lecture intégrale des fichiers audio par le flux, négociation de format d'`/oembed`

--- a/openspec/changes/specifier-contrat-public-existant/tasks.md
+++ b/openspec/changes/specifier-contrat-public-existant/tasks.md
@@ -21,9 +21,13 @@
 - [ ] 2.6 Vérifier qu'un `format` inconnu sur `/oembed` produit bien une réponse vide, et non une erreur
 - [ ] 2.7 Vérifier le déclenchement d'un désastre par paramètre d'URL, et le cumul de plusieurs recettes sur une même page
 - [ ] 2.8 Corriger les scénarios que la vérification contredit — le comportement observé fait foi, pas la lecture du code
+- [ ] 2.9 Reporter dans `openspec/specs/` les corrections issues de 2.8 : le corpus principal a été peuplé avant vérification, il porte les mêmes hypothèses
 
 ## 3. Promotion dans le corpus principal
 
-- [ ] 3.1 Une fois les specs vérifiées, les promouvoir dans `openspec/specs/` avec `openspec sync`
+- [x] 3.1 Promouvoir les specs dans `openspec/specs/`
+      — fait avant la vérification de la section 2, sur décision explicite. Le corpus
+      principal décrit donc un comportement lu dans le code, pas encore observé. La
+      section 2 reste due, et ses conclusions devront être reportées dans le corpus.
 - [ ] 3.2 Corriger `docs/memory-bank/README.adoc`, qui documente des routes inexistantes (`/random`, `/next`, `/prev`, `/md5/:md5sum`, `/feed.rss`) et un lecteur JW Player abandonné — ou acter que le corpus de specs le remplace sur ce périmètre
 - [ ] 3.3 Ouvrir un changement dédié pour chacun des défauts consignés : gabarit `max` d'un morceau isolé, lecture intégrale des fichiers audio par le flux, négociation de format d'`/oembed`

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,55 @@
+schema: spec-driven
+
+context: |
+  Musique Approximative — playlist quotidienne collaborative du collectif
+  Constructions Incongrues. Site en production : https://www.musiqueapproximative.net
+
+  Stack : Symfony 1.5 (legacy, fin de vie) + Doctrine 1.3, PHP 7.4, MySQL,
+  templates PHP. jQuery côté client, lecteur audio jPlayer.
+  Dev sous Docker Compose (nginx :8080, PHP :8001) ; déploiement par rsync (`make deploy`).
+
+  Deux applications : `src/apps/frontend` (public) et `src/apps/admin`.
+  Modèle central : `Post` (track_author, track_title, track_filename, body en Markdown,
+  slug, publish_on, contributeur `sfGuardUser`).
+  Plugin maison notable : `sfDesastrePlugin` (effets aléatoires, `desastres.yml`).
+
+  Contrat public à préserver — aucun test automatisé ne le couvre aujourd'hui :
+  routes `/post/:slug`, `/posts`, `/random`, `/next`, `/prev`, `/md5/:md5sum`,
+  `/feed.rss`, `/oembed` ; formats `json` (jsonapi.org), `xspf`, `max` (Max/MSP),
+  `rss`, `oembed` ; métadonnées OpenGraph.
+
+  Conventions du dépôt :
+  - Commits : Conventional Commits (release-please gère version et CHANGELOG).
+  - Documentation de référence : AsciiDoc / Antora sous `docs/`. OpenSpec ne la
+    remplace pas — les artefacts décrivent un changement, `docs/` décrit l'état stable.
+  - Langue : tout est rédigé en français (artefacts, specs, tâches, commits).
+  - Le code legacy ne se refactore pas à l'occasion : un change ne touche que ce
+    qu'il annonce.
+
+rules:
+  proposal:
+    - Rédiger en français.
+    - Inclure une section « Hors périmètre » explicite.
+    - Signaler si le changement touche le contrat public (routes, formats, OpenGraph).
+  specs:
+    - Rédiger en français, scénarios au format « Étant donné / Quand / Alors ».
+    - Spécifier le comportement observable (réponses HTTP, formats, métadonnées),
+      jamais l'implémentation Symfony 1.
+  design:
+    - Ne produire un design que si le changement touche plusieurs modules ou le
+      schéma de données ; sinon, s'en tenir à la proposition.
+    - Documenter les contraintes imposées par Symfony 1.5 / Doctrine 1.3 lorsqu'elles
+      orientent la solution.
+  tasks:
+    - Rédiger en français.
+    - "Inclure au moins une tâche de vérification manuelle : le projet n'a pas de
+      suite de tests sur laquelle s'appuyer."
+
+operations:
+  apply:
+    guidance:
+      - Vider le cache Symfony après toute modification de configuration ou de routing.
+      - Ne pas modifier `src/lib/vendor` ni les plugins tiers de `src/plugins`.
+  archive:
+    guidance:
+      - Vérifier que `docs/` reflète le nouvel état stable avant d'archiver.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -13,10 +13,16 @@ context: |
   slug, publish_on, contributeur `sfGuardUser`).
   Plugin maison notable : `sfDesastrePlugin` (effets aléatoires, `desastres.yml`).
 
-  Contrat public à préserver — aucun test automatisé ne le couvre aujourd'hui :
-  routes `/post/:slug`, `/posts`, `/random`, `/next`, `/prev`, `/md5/:md5sum`,
-  `/feed.rss`, `/oembed` ; formats `json` (jsonapi.org), `xspf`, `max` (Max/MSP),
-  `rss`, `oembed` ; métadonnées OpenGraph.
+  Contrat public à préserver — aucun test automatisé ne le couvre aujourd'hui.
+  Routes réelles, telles que définies dans `src/apps/frontend/config/routing.yml` :
+  `/` (redirection vers le dernier morceau), `/post/:slug`, `/post/md5/:md5sum`,
+  `/posts`, `/posts/feed`, `/posts/next`, `/posts/prev`, `/posts/random`, `/oembed`.
+  Formats de sortie : `json` (jsonapi.org), `xspf`, `max` (Max/MSP), flux RSS 2.01,
+  oEmbed (JSON et XML) ; métadonnées OpenGraph.
+
+  Attention : `docs/memory-bank/README.adoc` documente des routes qui n'existent pas
+  (`/random`, `/next`, `/prev`, `/md5/:md5sum`, `/feed.rss`) et un lecteur JW Player
+  qui n'est plus utilisé. Se référer au code, jamais à la banque de mémoire.
 
   Conventions du dépôt :
   - Commits : Conventional Commits (release-please gère version et CHANGELOG).

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,4 +1,4 @@
-schema: spec-driven
+schema: musique-approximative
 
 context: |
   Musique Approximative — playlist quotidienne collaborative du collectif
@@ -32,30 +32,19 @@ context: |
   - Le code legacy ne se refactore pas à l'occasion : un change ne touche que ce
     qu'il annonce.
 
+# Les règles de rédaction — français, section « Hors périmètre », comportement
+# observable plutôt qu'implémentation, tâche de vérification manuelle, cache et
+# plugins tiers — sont désormais portées par le schéma `musique-approximative`,
+# dans `openspec/schemas/`. Les répéter ici créerait deux sources de vérité qui
+# divergeraient. Ne subsistent ci-dessous que les consignes que le schéma ne
+# couvre pas.
+
 rules:
   proposal:
-    - Rédiger en français.
-    - Inclure une section « Hors périmètre » explicite.
-    - Signaler si le changement touche le contrat public (routes, formats, OpenGraph).
-  specs:
-    - Rédiger en français, scénarios au format « Étant donné / Quand / Alors ».
-    - Spécifier le comportement observable (réponses HTTP, formats, métadonnées),
-      jamais l'implémentation Symfony 1.
-  design:
-    - Ne produire un design que si le changement touche plusieurs modules ou le
-      schéma de données ; sinon, s'en tenir à la proposition.
-    - Documenter les contraintes imposées par Symfony 1.5 / Doctrine 1.3 lorsqu'elles
-      orientent la solution.
-  tasks:
-    - Rédiger en français.
-    - "Inclure au moins une tâche de vérification manuelle : le projet n'a pas de
-      suite de tests sur laquelle s'appuyer."
+    - Lorsqu'une contrainte du socle legacy oriente la solution retenue, la
+      documenter dans la section « Approche » plutôt que de la laisser implicite.
 
 operations:
-  apply:
-    guidance:
-      - Vider le cache Symfony après toute modification de configuration ou de routing.
-      - Ne pas modifier `src/lib/vendor` ni les plugins tiers de `src/plugins`.
   archive:
     guidance:
       - Vérifier que `docs/` reflète le nouvel état stable avant d'archiver.

--- a/openspec/schemas/musique-approximative/schema.yaml
+++ b/openspec/schemas/musique-approximative/schema.yaml
@@ -1,0 +1,223 @@
+name: musique-approximative
+version: 1
+description: Workflow allégé de Musique Approximative — proposition, specs, tâches
+
+# Dérivé de `spec-driven`. Deux écarts assumés :
+#
+# 1. L'artefact `design` est retiré du graphe. Sur ce projet — une seule
+#    application, un seul mainteneur — il faisait doublon avec la proposition à
+#    chaque changement. Ce qui relève du design y tient en une section. Un
+#    changement réellement structurant se discute avant d'être écrit, pas dans
+#    un document de plus.
+#
+# 2. Tout ce qui n'est pas analysé par l'outil est rédigé en français.
+#    Restent en anglais, parce que le parseur les cherche littéralement :
+#      - `## Why` et `## What Changes` dans la proposition ;
+#      - `## Purpose` et `## ADDED Requirements` — ainsi que MODIFIED, REMOVED
+#        et RENAMED — dans les specs ;
+#      - le préfixe `### Requirement:`, le nom qui suit étant libre ;
+#      - les mots-clés normatifs `SHALL` et `MUST`.
+#    En revanche `#### Scénario : ...` fonctionne : le parseur compte tout titre
+#    de niveau 4 sans regarder son libellé. `**QUAND**` et `**ALORS**` ne sont
+#    lus par personne, ils sont là pour le lecteur humain.
+
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Proposition — pourquoi ce changement, et ce qu'il touche
+    template: proposal.md
+    instruction: |
+      Rédige la proposition, qui établit POURQUOI ce changement est nécessaire.
+
+      Sections attendues :
+      - **Why** : une ou deux phrases sur le problème. Quel problème est résolu,
+        et pourquoi maintenant ? Titre en anglais, contenu en français : le
+        parseur cherche cette section par son nom.
+      - **What Changes** : liste de ce qui change. Sois précis sur les
+        comportements ajoutés, modifiés ou retirés. Marque les ruptures de
+        compatibilité par **BREAKING**. Même remarque sur le titre.
+      - **Hors périmètre** : ce que ce changement ne fait délibérément pas.
+        Section obligatoire. Sur du code legacy, la tentation de corriger
+        « tant qu'on y est » est le premier facteur de dérive.
+      - **Capacités** : quelles specs seront créées ou modifiées.
+        - **Nouvelles capacités** : chacune donnera un `specs/<nom>/spec.md`.
+          Nomme-les en kebab-case et en français, par exemple
+          `flux-syndication` ou `catalogue-morceaux`.
+        - **Capacités modifiées** : capacités existantes dont les EXIGENCES
+          changent, pas simplement l'implémentation. Vérifie les noms déjà
+          présents dans `openspec/specs/`. Laisse vide si aucune exigence ne
+          bouge.
+      - **Impact** : fichiers, routes, formats et systèmes touchés. Dis
+        explicitement si le contrat public est concerné.
+
+      Tout changement doit déclarer au moins une capacité, ou renoncer
+      explicitement aux specs en posant `skip_specs: true` dans le
+      `.openspec.yaml` du changement. N'utilise `skip_specs` que si aucun
+      comportement observable ne change : outillage, documentation, refactoring
+      pur. N'invente jamais une exigence pour satisfaire la validation.
+
+      Reste bref, une page suffit presque toujours.
+
+      Ce schéma n'a pas d'artefact de design. Si le changement est structurant —
+      plusieurs modules, schéma de données, dépendance nouvelle, migration —
+      décris l'approche retenue et les options écartées dans une section
+      **Approche** de cette proposition, puis arrête-toi pour en discuter avant
+      d'écrire les specs. Ne fais pas passer une décision d'architecture pour un
+      détail d'implémentation.
+    requires: []
+
+  - id: specs
+    generates: specs/**/*.md
+    description: Spécifications — le comportement observable, pas son implémentation
+    template: spec.md
+    instruction: |
+      Rédige les fichiers de spécification qui définissent CE QUE le système
+      doit faire.
+
+      Une spec est un contrat de comportement, pas un plan d'implémentation.
+
+      Ce qui a sa place dans une spec :
+      - le comportement observable dont dépendent les visiteurs ou les
+        consommateurs d'API ;
+      - les entrées, les sorties et les cas d'erreur ;
+      - les contraintes externes de compatibilité, de sécurité, de fiabilité ;
+      - des scénarios vérifiables un par un.
+
+      Ce qui n'y a pas sa place :
+      - les noms de classes, de méthodes ou de fichiers ;
+      - les choix de bibliothèque ou de framework ;
+      - les étapes d'implémentation.
+
+      Test rapide : si l'implémentation peut changer sans que le comportement
+      observable bouge, cela ne va pas dans la spec. En particulier, ne mentionne
+      jamais Symfony ni Doctrine dans une spec — ils ont vocation à disparaître,
+      pas le comportement.
+
+      Un fichier par capacité listée dans la proposition.
+      - Nouvelle capacité : reprends exactement le nom kebab-case de la
+        proposition, dans `specs/<capacité>/spec.md`.
+      - Capacité modifiée : reprends le nom du dossier existant sous
+        `openspec/specs/<capacité>/`.
+
+      Il faut au moins un fichier de spec, sauf si le changement pose
+      `skip_specs: true`.
+
+      FORMAT — les repères suivants sont analysés par l'outil et doivent être
+      écrits exactement ainsi, en anglais :
+
+      - les opérations de delta, en titre de niveau 2 :
+        `## ADDED Requirements` pour les exigences nouvelles ;
+        `## MODIFIED Requirements` pour un comportement changé, en recopiant
+        l'exigence ENTIÈRE, scénarios compris, avant de l'éditer ;
+        `## REMOVED Requirements`, avec **Raison** et **Migration** ;
+        `## RENAMED Requirements`, au format FROM:/TO:.
+      - chaque exigence : `### Requirement: <nom en français>`.
+      - le corps de chaque exigence contient `SHALL` ou `MUST` : ce sont les
+        seuls mots-clés normatifs reconnus. Évite « devrait » et « peut », qui
+        n'engagent à rien.
+
+      Tout le reste est en français :
+
+      - chaque scénario est un titre de niveau 4 : `#### Scénario : <nom>`.
+        **CRITIQUE** : exactement quatre dièses. Trois, ou une puce, et le
+        scénario est ignoré silencieusement.
+      - dans un scénario, écris `- **QUAND** <condition>` puis
+        `- **ALORS** <résultat attendu>`, et `- **ET**` pour enchaîner. Ces
+        mots ne sont lus par personne d'autre qu'un lecteur humain.
+      - toute exigence doit porter au moins un scénario.
+
+      Nouvelle capacité seulement : ouvre le fichier par une section
+      `## Purpose`, titre en anglais et contenu en français, d'une ou deux
+      phrases — au moins cinquante caractères, sans quoi
+      `openspec validate --strict` la signale comme trop brève. N'ajoute pas de
+      `## Purpose` au delta d'une capacité existante : elle en a déjà une, celle
+      du delta serait ignorée.
+
+      Ce projet n'a pas de suite de tests. Les specs en tiennent lieu : elles
+      sont le seul filet de non-régression, et le contrat à respecter si l'on
+      sort un jour de Symfony 1. Écris-les d'après le code, jamais de mémoire —
+      `docs/memory-bank/README.adoc` a dérivé sur plusieurs points et ne fait
+      pas foi.
+
+      Quand tu spécifies du comportement existant et que tu rencontres un
+      défaut, consigne-le tel qu'il est observable, puis signale-le en citation
+      sous l'exigence concernée. Une spec décrit ce qui est ; corriger relève
+      d'un autre changement.
+
+      Exemple :
+      ```
+      ## Purpose
+
+      Décrit ce que le site expose aux consommateurs d'un flux de syndication.
+
+      ## ADDED Requirements
+
+      ### Requirement: Publication du flux
+      Le système SHALL publier un flux RSS 2.01 en français.
+
+      #### Scénario : Accès au flux
+      - **QUAND** un consommateur demande `/posts/feed`
+      - **ALORS** un document RSS 2.01 est servi
+      - **ET** la langue déclarée est le français
+      ```
+    requires:
+      - proposal
+
+  - id: tasks
+    generates: tasks.md
+    description: Tâches — le découpage de l'implémentation et sa vérification
+    template: tasks.md
+    instruction: |
+      Rédige la liste des tâches qui découpe le travail d'implémentation.
+
+      **IMPORTANT : respecte le format de cases à cocher.** L'avancement est
+      suivi en analysant les `- [ ]`. Une tâche écrite autrement n'est pas
+      comptée.
+
+      Règles :
+      - regroupe les tâches sous des titres de niveau 2 numérotés ;
+      - chaque tâche est une case à cocher, au format `- [ ] X.Y Description` ;
+      - une tâche tient dans une séance de travail ;
+      - ordonne par dépendance, ce qui doit être fait d'abord vient d'abord ;
+      - rédige en français.
+
+      Ce projet n'a aucune suite de tests automatisés sur laquelle s'appuyer.
+      Termine donc toujours par une section de vérification manuelle, dont les
+      tâches sont assez précises pour être exécutées par quelqu'un d'autre :
+      quelle URL demander, quoi regarder dans la réponse, quel résultat attendre.
+
+      Si une vérification n'a pas pu être menée, faute d'environnement ou
+      d'accès, laisse sa case décochée et dis-le en clair dans le fichier. Une
+      case cochée signifie vérifiée, jamais « probablement bon ».
+
+      Exemple :
+      ```
+      ## 1. Métadonnées
+
+      - [ ] 1.1 Remplacer l'URL du lecteur dans l'action d'affichage d'un morceau
+      - [ ] 1.2 Aligner les dimensions déclarées sur celles de l'embed servi
+
+      ## 2. Vérification manuelle
+
+      - [ ] 2.1 Vider le cache, puis vérifier qu'aucune métadonnée de
+            `/post/:slug` ne référence de ressource `.swf`
+      ```
+
+      Appuie-toi sur les specs pour savoir ce qui doit être construit.
+    requires:
+      - specs
+
+apply:
+  requires: [tasks]
+  tracks: tasks.md
+  instruction: |
+    Lis la proposition et les specs, traite les tâches en attente, et coche-les
+    au fur et à mesure.
+
+    Ne coche jamais une tâche de vérification que tu n'as pas réellement
+    exécutée : dis ce qui bloque et laisse la case ouverte.
+
+    Ne touche ni à `src/lib/vendor` ni aux plugins tiers de `src/plugins`.
+    Vide le cache après toute modification de configuration ou de routing.
+    Si une spec se révèle fausse au contact du code, c'est la spec qu'il faut
+    corriger : arrête-toi et signale-le.

--- a/openspec/schemas/musique-approximative/templates/proposal.md
+++ b/openspec/schemas/musique-approximative/templates/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+<!-- Une ou deux phrases sur le problème. Qu'est-ce qui ne va pas aujourd'hui,
+     et pourquoi le traiter maintenant ? Le titre reste en anglais : le parseur
+     cherche cette section par son nom. Le contenu, lui, est en français. -->
+
+## What Changes
+
+<!-- Ce qui change, en liste. Sois précis sur les comportements ajoutés,
+     modifiés ou retirés. Marque les ruptures de compatibilité par **BREAKING**.
+     Titre en anglais pour la même raison que ci-dessus. -->
+
+### Hors périmètre
+
+<!-- Ce que ce changement ne fait délibérément pas, et pourquoi. Section
+     obligatoire : sur du code legacy, la tentation de corriger « tant qu'on y
+     est » est le premier facteur de dérive. -->
+
+## Capacités
+
+### Nouvelles capacités
+
+<!-- Capacités introduites. Chacune donnera un specs/<nom>/spec.md.
+     Nomme-les en kebab-case et en français. -->
+
+- `<nom>` : <ce que cette capacité recouvre>
+
+### Capacités modifiées
+
+<!-- Capacités existantes dont les EXIGENCES changent — pas simplement
+     l'implémentation. Reprends les noms présents dans openspec/specs/.
+     Laisse vide si aucune exigence ne bouge. Un changement sans aucune capacité
+     doit poser `skip_specs: true` dans son .openspec.yaml, sinon la validation
+     le rejette. N'invente jamais une exigence pour satisfaire la validation. -->
+
+- `<nom-existant>` : <quelle exigence change>
+
+## Impact
+
+<!-- Fichiers, routes, formats et systèmes touchés. Dis explicitement si le
+     contrat public est concerné : routes, formats de sortie, flux, oEmbed,
+     métadonnées. -->

--- a/openspec/schemas/musique-approximative/templates/spec.md
+++ b/openspec/schemas/musique-approximative/templates/spec.md
@@ -1,0 +1,27 @@
+## Purpose
+
+<!-- Nouvelle capacité seulement : une ou deux phrases, au moins cinquante
+     caractères, sur ce que recouvre cette capacité. Supprime cette section pour
+     le delta d'une capacité existante. Titre en anglais, contenu en français. -->
+
+## ADDED Requirements
+
+<!-- Titre en anglais : le parseur cherche cette section littéralement.
+     Variantes possibles selon l'opération : MODIFIED Requirements (recopier
+     l'exigence entière avant de l'éditer), REMOVED Requirements (avec **Raison**
+     et **Migration**), RENAMED Requirements (au format FROM:/TO:). -->
+
+### Requirement: <!-- nom de l'exigence, en français -->
+
+<!-- Le texte de l'exigence. Il DOIT contenir SHALL ou MUST : ce sont les seuls
+     mots-clés normatifs reconnus. « devrait » et « peut » n'engagent à rien. -->
+
+#### Scénario : <!-- nom du scénario -->
+
+<!-- Exactement quatre dièses. Avec trois, ou avec une puce, le scénario est
+     ignoré silencieusement. Le libellé « Scénario » est libre : le parseur
+     compte tout titre de niveau 4. -->
+
+- **QUAND** <!-- la condition -->
+- **ALORS** <!-- le résultat attendu -->
+- **ET** <!-- un résultat supplémentaire, si besoin -->

--- a/openspec/schemas/musique-approximative/templates/tasks.md
+++ b/openspec/schemas/musique-approximative/templates/tasks.md
@@ -1,0 +1,23 @@
+## 1. <!-- Nom du groupe de tâches -->
+
+<!-- Chaque tâche est une case à cocher `- [ ] X.Y`. L'avancement est suivi en
+     analysant ce format : une tâche écrite autrement n'est pas comptée. -->
+
+- [ ] 1.1 <!-- Description de la tâche -->
+- [ ] 1.2 <!-- Description de la tâche -->
+
+## 2. <!-- Nom du groupe de tâches -->
+
+- [ ] 2.1 <!-- Description de la tâche -->
+- [ ] 2.2 <!-- Description de la tâche -->
+
+## 3. Vérification manuelle
+
+<!-- Section obligatoire : ce projet n'a aucune suite de tests automatisés.
+     Chaque tâche doit être exécutable par quelqu'un d'autre — quelle URL
+     demander, quoi regarder, quel résultat attendre.
+
+     Une case cochée signifie vérifiée. Si une vérification n'a pas pu être
+     menée, laisse la case ouverte et dis-le en clair ici même. -->
+
+- [ ] 3.1 <!-- Quelle vérification, sur quoi, avec quel résultat attendu -->

--- a/openspec/specs/catalogue-morceaux/spec.md
+++ b/openspec/specs/catalogue-morceaux/spec.md
@@ -1,0 +1,167 @@
+# Spécification : catalogue-morceaux
+
+## Purpose
+
+Définit quels morceaux sont publiquement visibles, dans quel ordre ils se succèdent, et
+comment un visiteur ou un consommateur d'API navigue de l'un à l'autre.
+
+## Requirements
+
+### Requirement: Définition d'un morceau publiable
+
+Le système SHALL ne rendre publiquement accessible qu'un morceau marqué en ligne et dont
+la date de publication est atteinte. La date de publication est considérée atteinte
+jusqu'à deux heures dans le futur.
+
+#### Scénario : Morceau hors ligne
+
+- **QUAND** un morceau a son indicateur de mise en ligne à faux
+- **ALORS** il n'apparaît dans aucune liste, aucun flux et aucune navigation
+- **ET** son accès direct par identifiant renvoie une erreur 404
+
+#### Scénario : Morceau à publication future
+
+- **QUAND** la date de publication d'un morceau est postérieure à l'instant courant de
+  plus de deux heures
+- **ALORS** le morceau n'est pas publiquement accessible
+
+#### Scénario : Morceau publiable sous peu
+
+- **QUAND** la date de publication d'un morceau se situe dans les deux heures à venir
+- **ALORS** le morceau est déjà publiquement accessible
+
+#### Scénario : Morceau sans identifiant d'URL
+
+- **QUAND** un morceau a un identifiant d'URL vide ou absent
+- **ALORS** il est exclu des listes, afin de ne pas provoquer d'erreur de routage
+
+### Requirement: Ordre du catalogue
+
+Le système SHALL présenter les morceaux du plus récemment publié au plus ancien.
+
+#### Scénario : Ordre d'une liste
+
+- **QUAND** un consommateur demande la liste des morceaux
+- **ALORS** les morceaux sont ordonnés par date de publication décroissante
+
+### Requirement: Accès au dernier morceau publié
+
+La racine du site SHALL rediriger vers le morceau publiable le plus récent.
+
+#### Scénario : Redirection depuis la racine
+
+- **QUAND** un visiteur demande `/`
+- **ALORS** il est redirigé vers la page du morceau publiable le plus récent
+
+#### Scénario : Redirection filtrée par contributeur
+
+- **QUAND** un visiteur demande `/` avec le paramètre `c` valant le nom d'un contributeur
+- **ALORS** il est redirigé vers le morceau publiable le plus récent de ce contributeur
+- **ET** le paramètre `c` est conservé dans l'URL de destination
+
+#### Scénario : Aucun morceau publiable
+
+- **QUAND** aucun morceau publiable n'existe pour les critères demandés
+- **ALORS** la réponse est une erreur 404
+
+### Requirement: Consultation d'un morceau
+
+Le système SHALL exposer chaque morceau publiable à une URL stable construite sur son
+identifiant d'URL.
+
+#### Scénario : Morceau existant
+
+- **QUAND** un visiteur demande `/post/:slug` pour un morceau publiable
+- **ALORS** la page du morceau est servie
+
+#### Scénario : Identifiant inconnu
+
+- **QUAND** l'identifiant d'URL ne correspond à aucun morceau publiable
+- **ALORS** la réponse est une erreur 404
+
+### Requirement: Navigation séquentielle
+
+Le système SHALL permettre de passer d'un morceau au suivant ou au précédent selon
+l'ordre de publication, en respectant les filtres de navigation en cours.
+
+#### Scénario : Morceau suivant
+
+- **QUAND** un consommateur demande `/posts/next` avec le paramètre `current` valant
+  l'identifiant numérique d'un morceau
+- **ALORS** la réponse décrit le morceau publiable immédiatement plus récent
+
+#### Scénario : Morceau précédent
+
+- **QUAND** un consommateur demande `/posts/prev` avec le paramètre `current` valant
+  l'identifiant numérique d'un morceau
+- **ALORS** la réponse décrit le morceau publiable immédiatement plus ancien
+
+#### Scénario : Navigation restreinte à un contributeur
+
+- **QUAND** le paramètre `c` accompagne la demande de navigation
+- **ALORS** seuls les morceaux de ce contributeur sont considérés
+
+### Requirement: Tirage aléatoire
+
+Le système SHALL exposer un morceau publiable tiré au hasard.
+
+#### Scénario : Morceau aléatoire
+
+- **QUAND** un consommateur demande `/posts/random`
+- **ALORS** la réponse décrit un morceau publiable choisi aléatoirement
+
+#### Scénario : Tirage restreint à un contributeur
+
+- **QUAND** le paramètre `c` accompagne la demande
+- **ALORS** le tirage ne porte que sur les morceaux de ce contributeur
+
+### Requirement: Réponse de navigation
+
+Les points d'entrée de navigation SHALL répondre en JSON avec l'adresse et le libellé du
+morceau désigné.
+
+#### Scénario : Structure de la réponse
+
+- **QUAND** un consommateur interroge `/posts/next`, `/posts/prev` ou `/posts/random`
+- **ALORS** le type de contenu est `application/json`
+- **ET** le corps contient un champ `url` valant l'adresse de la page du morceau
+- **ET** le corps contient un champ `title` valant « artiste - titre »
+
+### Requirement: Recherche par empreinte du fichier
+
+Le système SHALL permettre de retrouver un morceau publiable à partir de l'empreinte MD5
+de son fichier audio.
+
+#### Scénario : Empreinte connue
+
+- **QUAND** un consommateur demande `/post/md5/:md5sum` pour une empreinte correspondant à
+  un morceau publiable
+- **ALORS** le type de contenu est `application/json`
+- **ET** le corps est la représentation JSON complète du morceau
+
+### Requirement: Liste et recherche plein texte
+
+Le système SHALL exposer la liste des morceaux publiables, filtrable par contributeur ou
+interrogeable par termes de recherche.
+
+#### Scénario : Liste complète
+
+- **QUAND** un visiteur demande `/posts`
+- **ALORS** tous les morceaux publiables sont listés, du plus récent au plus ancien
+
+#### Scénario : Liste d'un contributeur
+
+- **QUAND** le paramètre `c` accompagne la demande
+- **ALORS** seuls les morceaux de ce contributeur sont listés
+- **ET** le titre de la page annonce la playlist de ce contributeur
+
+#### Scénario : Recherche par termes
+
+- **QUAND** le paramètre `q` accompagne la demande
+- **ALORS** seuls les morceaux publiables correspondant aux termes sont listés
+- **ET** le titre de la page annonce le nombre de résultats et les termes recherchés
+
+#### Scénario : Résultats de recherche non publiables
+
+- **QUAND** la recherche remonte un morceau qui n'est pas publiable
+- **ALORS** ce morceau est écarté des résultats

--- a/openspec/specs/desastres/spec.md
+++ b/openspec/specs/desastres/spec.md
@@ -1,0 +1,97 @@
+# Spécification : desastres
+
+## Purpose
+
+Décrit l'altération volontaire et imprévisible des pages du site par des « désastres » :
+des recettes visuelles ou sonores déclenchées par des règles portant sur le contenu
+consulté. C'est un parti pris éditorial du site, pas un défaut.
+
+## Requirements
+
+### Requirement: Déclenchement conditionnel
+
+Le système SHALL évaluer, à chaque affichage d'une page de morceau ou de liste, un jeu de
+règles déclarées en configuration, et SHALL appliquer les recettes des règles retenues.
+
+#### Scénario : Évaluation sur une page de morceau
+
+- **QUAND** un visiteur consulte une page de morceau
+- **ALORS** les règles sont évaluées avec, en contexte, l'artiste, le titre du morceau et
+  le contributeur
+
+#### Scénario : Évaluation sur une page de liste
+
+- **QUAND** un visiteur consulte une liste de morceaux
+- **ALORS** les règles sont évaluées avec, en contexte, les termes de recherche et le
+  contributeur demandés
+
+#### Scénario : Paramètres de la requête pris en compte
+
+- **QUAND** les règles sont évaluées pour un affichage
+- **ALORS** les paramètres de la requête sont joints au contexte d'évaluation, ce qui
+  permet de déclencher un désastre par l'URL
+
+#### Scénario : Aucune règle satisfaite
+
+- **QUAND** aucune règle ne correspond
+- **ALORS** la page est servie sans altération
+
+### Requirement: Part d'aléatoire
+
+Une règle SHALL pouvoir ne se déclencher qu'une fois sur plusieurs, afin que deux
+consultations de la même page ne produisent pas nécessairement le même effet.
+
+#### Scénario : Règle probabiliste
+
+- **QUAND** une règle déclare une probabilité inférieure à 1
+- **ALORS** elle ne se déclenche qu'une partie du temps, pour un même contexte
+
+#### Scénario : Règle certaine
+
+- **QUAND** une règle déclare une probabilité de 1
+- **ALORS** elle se déclenche à chaque fois que son expression est satisfaite
+
+### Requirement: Application d'une recette
+
+L'application d'une recette SHALL enrichir la réponse des ressources du désastre
+correspondant, sans modifier le contenu servi.
+
+#### Scénario : Ressources du désastre
+
+- **QUAND** une recette est appliquée
+- **ALORS** les feuilles de style du désastre correspondant sont ajoutées à la réponse
+- **ET** ses scripts sont ajoutés à la réponse
+
+#### Scénario : Scripts externes déclarés
+
+- **QUAND** la recette déclare des scripts externes
+- **ALORS** ces scripts sont ajoutés à la réponse en plus des ressources du désastre
+
+#### Scénario : Options transmises au désastre
+
+- **QUAND** la recette déclare des options
+- **ALORS** ces options sont mises à disposition du désastre côté client
+
+#### Scénario : Recette désactivée
+
+- **QUAND** une recette est marquée comme désactivée en configuration
+- **ALORS** elle n'est jamais appliquée
+
+### Requirement: Cumul des désastres
+
+Plusieurs désastres SHALL pouvoir s'appliquer à une même page.
+
+#### Scénario : Règles multiples satisfaites
+
+- **QUAND** plusieurs règles se déclenchent pour un même affichage
+- **ALORS** les recettes de chacune sont appliquées à la réponse
+
+### Requirement: Absence de configuration
+
+Le système SHALL servir les pages normalement lorsque la configuration des désastres est
+absente.
+
+#### Scénario : Fichier de configuration manquant
+
+- **QUAND** le fichier de configuration des désastres n'existe pas
+- **ALORS** aucune altération n'est appliquée et la page est servie normalement

--- a/openspec/specs/embarquement-oembed/spec.md
+++ b/openspec/specs/embarquement-oembed/spec.md
@@ -1,0 +1,104 @@
+# Spécification : embarquement-oembed
+
+## Purpose
+
+Décrit comment un site tiers obtient un lecteur embarquable pour un morceau, par le
+protocole oEmbed ou en pointant directement le gabarit d'embarquement.
+
+## Requirements
+
+### Requirement: Point d'entrée oEmbed
+
+Le système SHALL répondre aux demandes oEmbed portant sur l'adresse d'un morceau
+publiable.
+
+#### Scénario : Demande sur un morceau publiable
+
+- **QUAND** un consommateur demande `/oembed` avec le paramètre `url` valant l'adresse
+  d'un morceau publiable
+- **ALORS** une réponse oEmbed décrivant ce morceau est servie
+
+#### Scénario : Morceau inconnu
+
+- **QUAND** l'adresse fournie ne désigne aucun morceau publiable
+- **ALORS** la réponse est une erreur 404
+
+#### Scénario : Résolution du morceau depuis l'adresse
+
+- **QUAND** l'adresse fournie comporte un chemin
+- **ALORS** le morceau est résolu à partir du dernier segment de ce chemin, les segments
+  précédents étant ignorés
+
+### Requirement: Contenu de la réponse oEmbed
+
+La réponse oEmbed SHALL être de type `rich` et SHALL porter un fragment HTML prêt à être
+inséré par le consommateur.
+
+#### Scénario : Champs de la réponse
+
+- **QUAND** une réponse oEmbed est servie
+- **ALORS** elle porte `version` valant 1 et `type` valant `rich`
+- **ET** elle porte `provider_name` et `provider_url` identifiant le site
+- **ET** elle porte `title` valant « artiste - titre »
+- **ET** elle porte `description` valant le corps du post débarrassé de son balisage
+- **ET** elle porte `width` et `height` correspondant aux dimensions du gabarit
+  d'embarquement effectivement servi
+
+#### Scénario : Fragment embarquable
+
+- **QUAND** une réponse oEmbed est servie
+- **ALORS** le champ `html` contient un élément `iframe` sans bordure ni défilement
+- **ET** l'adresse source de cet `iframe` est celle de la page du morceau assortie du
+  paramètre `embed`
+- **ET** ses dimensions sont celles déclarées par `width` et `height`
+
+### Requirement: Négociation du format oEmbed
+
+La réponse oEmbed SHALL être servie en JSON par défaut, et en XML sur demande explicite.
+
+#### Scénario : Format JSON par défaut
+
+- **QUAND** aucun paramètre `format` n'est fourni, ou qu'il vaut `json`
+- **ALORS** la réponse est un objet JSON
+- **ET** le type de contenu est `application/json`
+
+#### Scénario : Format XML
+
+- **QUAND** le paramètre `format` vaut `xml`
+- **ALORS** la réponse est un document XML dont la racine est `oembed`
+- **ET** chaque champ devient un élément enfant, son contenu étant échappé
+- **ET** le type de contenu est `text/xml+oembed`
+
+#### Scénario : Format inconnu
+
+- **QUAND** le paramètre `format` vaut autre chose que `json` ou `xml`
+- **ALORS** aucune donnée n'est encodée et la réponse est inexploitable
+
+> Comportement constaté, non souhaitable : ni erreur, ni repli sur le format par défaut.
+> Le type de contenu `application/json+oembed` attendu par la spécification oEmbed n'est
+> par ailleurs pas déclaré. À traiter par un changement dédié.
+
+### Requirement: Gabarit d'embarquement
+
+Le système SHALL servir, pour un morceau publiable, un document autonome contenant un
+lecteur audio et les liens de retour vers le site.
+
+#### Scénario : Demande du gabarit
+
+- **QUAND** un visiteur demande `/post/:slug` avec le paramètre `embed`
+- **ALORS** un document autonome est servi, sans l'habillage du site
+
+#### Scénario : Contenu du gabarit
+
+- **QUAND** le gabarit d'embarquement d'un morceau est servi
+- **ALORS** le document porte le titre du morceau, lié à sa page, ouvrant dans un nouvel
+  onglet
+- **ET** il porte le corps du post rendu depuis son Markdown
+- **ET** il porte un lecteur audio HTML avec ses contrôles, dont la source est le
+  fichier audio du morceau
+- **ET** il mentionne le contributeur, lié à sa playlist, et le site
+
+#### Scénario : Variante d'embarquement
+
+- **QUAND** le paramètre `embed` porte une valeur
+- **ALORS** le gabarit correspondant à cette variante est servi si il existe

--- a/openspec/specs/flux-syndication/spec.md
+++ b/openspec/specs/flux-syndication/spec.md
@@ -1,0 +1,85 @@
+# Spécification : flux-syndication
+
+## Purpose
+
+Décrit le flux de syndication publié par le site, son contenu, ses filtres et les
+attentes des agrégateurs et lecteurs de podcast qui le consomment.
+
+## Requirements
+
+### Requirement: Publication du flux
+
+Le système SHALL publier un flux RSS 2.01 en français décrivant les morceaux publiables.
+
+#### Scénario : Accès au flux
+
+- **QUAND** un consommateur demande `/posts/feed`
+- **ALORS** un document RSS 2.01 est servi
+- **ET** la langue déclarée est le français
+- **ET** le flux porte le titre du site, son adresse et sa description
+
+#### Scénario : Illustration du flux
+
+- **QUAND** un consommateur demande `/posts/feed`
+- **ALORS** le flux déclare une favicône et une image de logo servies par le site
+- **ET** l'image et le titre de l'illustration renvoient à l'adresse du site
+
+### Requirement: Volume et filtrage du flux
+
+Le flux SHALL contenir au plus cinquante morceaux par défaut, et SHALL pouvoir être
+restreint à un contributeur ou à un nombre d'items choisi.
+
+#### Scénario : Volume par défaut
+
+- **QUAND** aucun paramètre de volume n'est fourni
+- **ALORS** le flux contient au plus les cinquante morceaux publiables les plus récents
+
+#### Scénario : Volume choisi
+
+- **QUAND** le paramètre `count` accompagne la demande
+- **ALORS** le flux contient au plus ce nombre de morceaux
+
+#### Scénario : Flux d'un contributeur
+
+- **QUAND** le paramètre `contributor` accompagne la demande
+- **ALORS** le flux ne contient que les morceaux de ce contributeur
+
+### Requirement: Contenu d'un item
+
+Chaque item du flux SHALL identifier le morceau, dater sa publication et permettre son
+écoute directe.
+
+#### Scénario : Identification de l'item
+
+- **QUAND** un morceau figure dans le flux
+- **ALORS** le titre de l'item vaut « artiste - titre »
+- **ET** l'item renvoie à la page du morceau
+- **ET** l'auteur de l'item est le nom d'affichage du contributeur
+- **ET** l'identifiant unique de l'item est l'identifiant d'URL du morceau
+- **ET** la date de publication de l'item est la date de publication du morceau
+
+#### Scénario : Description de l'item
+
+- **QUAND** un morceau figure dans le flux
+- **ALORS** la description contient une illustration cliquable renvoyant à la page du
+  morceau
+- **ET** elle contient le corps du post rendu depuis son Markdown
+- **ET** elle mentionne le contributeur
+
+#### Scénario : Illustration glitchée
+
+- **QUAND** l'effet de glitch du logo est actif pour cet item
+- **ALORS** l'illustration de la description est produite par le service de glitch, avec
+  l'identifiant du morceau comme graine
+
+#### Scénario : Fichier joint pour l'écoute
+
+- **QUAND** un morceau figure dans le flux
+- **ALORS** l'item porte une pièce jointe désignant l'adresse absolue du fichier audio
+- **ET** le type déclaré de la pièce jointe est `audio/mpeg`
+- **ET** la taille déclarée est celle du fichier, ou zéro lorsque le fichier n'est pas
+  lisible sur le serveur
+
+> Comportement constaté, non souhaitable : la taille de la pièce jointe est obtenue en
+> chargeant l'intégralité de chaque fichier audio en mémoire, pour chaque item et à
+> chaque demande du flux. À traiter par un changement dédié.

--- a/openspec/specs/formats-de-sortie/spec.md
+++ b/openspec/specs/formats-de-sortie/spec.md
@@ -1,0 +1,124 @@
+# Spécification : formats-de-sortie
+
+## Purpose
+
+Décrit les représentations alternatives d'un morceau ou d'une liste de morceaux, et la
+manière dont un consommateur les demande.
+
+## Requirements
+
+### Requirement: Sélection du format
+
+Le système SHALL servir une représentation alternative lorsque le paramètre `format`
+désigne un format connu, et SHALL déclarer le type de contenu correspondant.
+
+#### Scénario : Formats reconnus
+
+- **QUAND** un consommateur ajoute `format=json`, `format=xspf` ou `format=max` à une
+  demande de morceau ou de liste
+- **ALORS** la réponse est servie sans gabarit d'habillage
+- **ET** le type de contenu est respectivement `application/json`,
+  `application/xspf+xml` ou `application/maxmsp+text`
+
+#### Scénario : Format inconnu
+
+- **QUAND** le paramètre `format` désigne une valeur non reconnue
+- **ALORS** la page est servie dans sa représentation HTML habituelle
+
+#### Scénario : Formats annoncés au visiteur
+
+- **QUAND** une page de morceau ou de liste est servie en HTML
+- **ALORS** les formats `json` et `xspf` sont annoncés au visiteur
+- **ET** le format `max` ne l'est pas, bien qu'il reste accessible
+
+### Requirement: Représentation JSON d'un morceau
+
+La représentation JSON d'un morceau SHALL suivre la convention jsonapi.org fondée sur les
+URL, et SHALL exposer le morceau, sa piste, son contributeur et ses liens de navigation.
+
+#### Scénario : Identité et adresse
+
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** le champ `id` vaut l'identifiant d'URL du morceau
+- **ET** le champ `href` vaut l'adresse absolue de sa représentation JSON
+
+#### Scénario : Corps du morceau
+
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** le champ `body` est un objet portant `markdown`, le texte source, et `html`,
+  son rendu
+
+#### Scénario : Description de la piste
+
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** le champ `track` est un objet portant `href` (adresse absolue du fichier
+  audio), `title`, `author` et `md5`
+- **ET** les champs bruts correspondants n'apparaissent pas à la racine de l'objet
+
+#### Scénario : Description du contributeur
+
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** le champ `contributor` est un objet portant `name`, `slug` et `href_website`
+
+#### Scénario : Liens de navigation
+
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** le champ `links` porte `contributor_playlist`, adresse de la liste JSON des
+  morceaux du contributeur
+- **ET** `links` porte `avatar`, adresse de l'illustration associée au morceau
+- **ET** `links` porte `post_previous` et `post_next` lorsque ces morceaux sont connus
+  de l'appelant
+
+#### Scénario : Champs jamais exposés
+
+- **QUAND** un consommateur demande la représentation JSON d'un morceau
+- **ALORS** les champs internes de mise en ligne, de révision et l'objet utilisateur
+  complet sont absents de la réponse
+
+### Requirement: Représentation XSPF d'une liste
+
+La représentation XSPF d'une liste SHALL être une playlist valide, encodée en UTF-8,
+dont chaque piste porte son adresse de lecture directe.
+
+#### Scénario : Structure de la playlist
+
+- **QUAND** un consommateur demande une liste au format `xspf`
+- **ALORS** la réponse est un document XSPF déclarant l'encodage UTF-8
+- **ET** chaque piste porte le créateur, le titre, le corps du post en annotation,
+  l'adresse de la page du morceau en information, et l'adresse absolue du fichier audio
+  en localisation
+
+#### Scénario : Titre de la playlist selon le filtre
+
+- **QUAND** la liste est filtrée par contributeur
+- **ALORS** le titre de la playlist mentionne le nom d'affichage de ce contributeur
+- **ET** lorsque la liste résulte d'une recherche, le titre mentionne les termes
+  recherchés
+- **ET** en l'absence de filtre, le titre annonce l'ensemble des morceaux
+
+### Requirement: Représentation Max/MSP d'une liste
+
+La représentation `max` d'une liste SHALL être une suite de lignes textuelles, une par
+morceau, dont les champs sont débarrassés des caractères qui casseraient l'analyse côté
+Max/MSP.
+
+#### Scénario : Ligne par morceau
+
+- **QUAND** un consommateur demande une liste au format `max`
+- **ALORS** chaque morceau produit une ligne portant son rang, l'artiste, le titre,
+  l'adresse du fichier audio, l'adresse de la page, le contributeur, le nombre total de
+  morceaux et le corps du post
+- **ET** les guillemets et retours à la ligne sont retirés des champs textuels
+
+### Requirement: Représentation Max/MSP d'un morceau isolé
+
+Le format `max` appliqué à un morceau isolé SHALL être considéré comme non implémenté.
+
+#### Scénario : Demande du format max sur un morceau
+
+- **QUAND** un consommateur demande `/post/:slug` au format `max`
+- **ALORS** la réponse ne contient aucune donnée exploitable
+
+> Comportement constaté, non souhaitable : le gabarit correspondant ne contient que la
+> mention `TODO`, alors que le format est annoncé comme disponible par la sélection de
+> format. À traiter par un changement dédié.

--- a/openspec/specs/metadonnees-partage/spec.md
+++ b/openspec/specs/metadonnees-partage/spec.md
@@ -1,0 +1,96 @@
+# Spécification : metadonnees-partage
+
+## Purpose
+
+Décrit les métadonnées OpenGraph qu'une page de morceau expose aux plateformes
+tierces, afin qu'un lien partagé restitue le titre, l'illustration et un lecteur
+audio réellement jouable par le destinataire.
+
+## Requirements
+
+### Requirement: Identification du morceau partagé
+
+La page d'un morceau SHALL exposer les métadonnées OpenGraph permettant d'identifier
+le contenu : titre, description et URL canonique.
+
+#### Scénario : Métadonnées d'identification présentes
+
+- **QUAND** un consommateur récupère le HTML de `/post/:slug`
+- **ALORS** la page contient `og:title` valant « `artiste` - `titre` | `titre du site` »
+- **ET** la page contient `og:description` contenant le corps du post débarrassé de
+  son balisage Markdown et HTML
+- **ET** la page contient `og:url` valant l'URL absolue canonique du morceau
+
+#### Scénario : Titre enrichi du contributeur
+
+- **QUAND** la page est demandée avec le paramètre de contributeur `c`
+- **ALORS** `og:title` mentionne en plus « Playlist de `contributeur` »
+
+### Requirement: Illustration du partage
+
+La page d'un morceau SHALL exposer une illustration carrée de 476×476 pixels au
+format PNG.
+
+#### Scénario : Illustration déclarée
+
+- **QUAND** un consommateur récupère le HTML de `/post/:slug`
+- **ALORS** la page contient `og:image` pointant vers une image PNG accessible
+  publiquement
+- **ET** `og:image:type` vaut `image/png`
+- **ET** `og:image:width` et `og:image:height` valent tous deux `476`
+
+#### Scénario : Illustration glitchée
+
+- **QUAND** l'effet de glitch du logo est actif pour cet affichage
+- **ALORS** `og:image` pointe vers le service de glitch avec l'identifiant du morceau
+  comme graine, ce qui rend l'illustration reproductible pour un morceau donné
+
+### Requirement: Lecteur embarquable jouable
+
+La page d'un morceau SHALL déclarer un lecteur embarquable sous forme de document
+HTML, et SHALL NOT déclarer de ressource nécessitant un greffon de navigateur
+obsolète.
+
+#### Scénario : Lecteur déclaré en HTML
+
+- **QUAND** un consommateur récupère le HTML de `/post/:slug`
+- **ALORS** `og:video` et `og:video:secure_url` pointent vers l'URL d'embed HTML du
+  morceau, servie en HTTPS
+- **ET** `og:video:type` vaut `text/html`
+- **ET** `og:video:width` et `og:video:height` correspondent aux dimensions du
+  document d'embed effectivement servi
+
+#### Scénario : Aucune ressource Flash déclarée
+
+- **QUAND** un consommateur inspecte l'ensemble des métadonnées de `/post/:slug`
+- **ALORS** aucune métadonnée ne référence une ressource `.swf`
+- **ET** aucune métadonnée ne déclare le type `application/x-shockwave-flash`
+
+#### Scénario : Cohérence avec la réponse oEmbed
+
+- **QUAND** un consommateur compare les métadonnées de la page et la réponse du point
+  d'entrée `/oembed` pour le même morceau
+- **ALORS** l'URL d'embed déclarée par `og:video` et celle contenue dans le champ
+  `html` de la réponse oEmbed désignent la même ressource
+- **ET** les dimensions déclarées de part et d'autre sont identiques
+
+### Requirement: Accès direct au fichier audio
+
+La page d'un morceau SHALL exposer l'URL du fichier audio, afin que les plateformes
+qui n'affichent pas d'iframe tierce puissent tout de même proposer une écoute.
+
+#### Scénario : Fichier audio déclaré
+
+- **QUAND** un consommateur récupère le HTML de `/post/:slug`
+- **ALORS** `og:audio` et `og:audio:secure_url` pointent vers le fichier audio du
+  morceau, servi en HTTPS
+- **ET** `og:audio:type` déclare le type MIME du fichier servi
+
+### Requirement: Typage du contenu partagé
+
+La page d'un morceau SHALL se déclarer comme un morceau de musique.
+
+#### Scénario : Type OpenGraph
+
+- **QUAND** un consommateur récupère le HTML de `/post/:slug`
+- **ALORS** `og:type` vaut `music.song`

--- a/src/apps/frontend/modules/post/actions/actions.class.php
+++ b/src/apps/frontend/modules/post/actions/actions.class.php
@@ -13,10 +13,44 @@ use Nyholm\Psr7\ServerRequest;
  */
 class postActions extends sfActions
 {
+  /**
+   * Dimensions du lecteur embarquable servi par /post/:slug?embed.
+   * Partagées par les métadonnées OpenGraph et la réponse oEmbed, qui doivent
+   * annoncer les mêmes valeurs.
+   */
+  const EMBED_WIDTH = 510;
+  const EMBED_HEIGHT = 220;
+
   private function getDisaster(sfWebRequest $request, sfWebResponse $response, array $query = [])
   {
     $this->getContext()->getConfiguration()->loadHelpers('Desastre');
     apply_desastre($request, $response, $query);
+  }
+
+  /**
+   * Force une URL absolue en HTTPS.
+   */
+  private function toSecureUrl($url)
+  {
+    return preg_replace('#^http://#i', 'https://', $url);
+  }
+
+  /**
+   * Type MIME d'un fichier de piste, déduit de son extension.
+   */
+  private function getTrackMimeType($filename)
+  {
+    $types = array(
+      'mp3'  => 'audio/mpeg',
+      'ogg'  => 'audio/ogg',
+      'oga'  => 'audio/ogg',
+      'm4a'  => 'audio/mp4',
+      'flac' => 'audio/flac',
+      'wav'  => 'audio/wav',
+    );
+    $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+
+    return isset($types[$extension]) ? $types[$extension] : 'audio/mpeg';
   }
 
   /**
@@ -51,7 +85,8 @@ class postActions extends sfActions
     $posts_count = Doctrine_Core::getTable('Post')->countOnlinePosts();
 
     // Define opengraph metadata (see http://ogp.me/)
-    $urlTrack = rawurlencode(sprintf('%s/%s', sfConfig::get('app_urls_tracks'), $post->track_filename));
+    $urlTrack = $this->toSecureUrl(sprintf('%s/%s', sfConfig::get('app_urls_tracks'), rawurlencode($post->track_filename)));
+    $urlEmbed = $this->toSecureUrl(sprintf('%s?embed', $this->getController()->genUrl('@post_show?slug='.$post->slug, true)));
     $this->getContext()->getConfiguration()->loadHelpers('Markdown');
     $this->getResponse()->addMeta('og:title', $title);
     $this->getResponse()->addMeta('og:description', trim(strip_tags(Markdown($post->body))));
@@ -68,28 +103,15 @@ class postActions extends sfActions
     $this->getResponse()->addMeta('og:image:type', 'image/png');
     $this->getResponse()->addMeta('og:image:height', '476');
     $this->getResponse()->addMeta('og:image:width', '476');
-    $this->getResponse()->addMeta('og:type', 'video');
-    $this->getResponse()->addMeta(
-      'og:video',
-      sprintf(
-        'http://%s/player.swf?autostart=true&file=%s&height=476&width=476&image=%s',
-        sfConfig::get('app_domain'),
-        $urlTrack,
-        $urlImg
-      )
-    );
-    $this->getResponse()->addMeta(
-      'og:video:secure_url',
-      sprintf(
-        'https://%s/player.swf?autostart=true&file=%s&height=476&width=476&image=%s',
-        sfConfig::get('app_domain'),
-        $urlTrack,
-        $urlImg
-      )
-    );
-    $this->getResponse()->addMeta('og:video:type', 'application/x-shockwave-flash');
-    $this->getResponse()->addMeta('og:video:height', '476');
-    $this->getResponse()->addMeta('og:video:width', '476');
+    $this->getResponse()->addMeta('og:type', 'music.song');
+    $this->getResponse()->addMeta('og:video', $urlEmbed);
+    $this->getResponse()->addMeta('og:video:secure_url', $urlEmbed);
+    $this->getResponse()->addMeta('og:video:type', 'text/html');
+    $this->getResponse()->addMeta('og:video:height', (string) self::EMBED_HEIGHT);
+    $this->getResponse()->addMeta('og:video:width', (string) self::EMBED_WIDTH);
+    $this->getResponse()->addMeta('og:audio', $urlTrack);
+    $this->getResponse()->addMeta('og:audio:secure_url', $urlTrack);
+    $this->getResponse()->addMeta('og:audio:type', $this->getTrackMimeType($post->track_filename));
     $this->getResponse()->addMeta('og:url', $this->getController()->genUrl('@post_show?slug='.$post->slug, true));
 
     // Gather common query parameters
@@ -305,11 +327,11 @@ class postActions extends sfActions
       'type'          => 'rich',
       'provider_name' => 'MusiqueApproximative',
       'provider_url'  => sfConfig::get('app_url_root'),
-      'height'        => 220,
-      'width'         => 510,
+      'height'        => self::EMBED_HEIGHT,
+      'width'         => self::EMBED_WIDTH,
       'title'         => sprintf('%s - %s', $post->track_author, $post->track_title),
       'description'   => strip_tags(Markdown($post->body)),
-      'html'          => sprintf('<iframe width="510" height="220" scrolling="no" frameborder="no" src="%s?embed"></iframe>', $this->getController()->genUrl('@post_show?slug='.$post->slug, true))
+      'html'          => sprintf('<iframe width="%d" height="%d" scrolling="no" frameborder="no" src="%s?embed"></iframe>', self::EMBED_WIDTH, self::EMBED_HEIGHT, $this->getController()->genUrl('@post_show?slug='.$post->slug, true))
     );
 
     // Encode data depending on requested format


### PR DESCRIPTION
Adoption d'[OpenSpec](https://github.com/Fission-AI/OpenSpec) et de son workflow OPSX, passée sur de vrais changements de bout en bout plutôt qu'évaluée sur le papier — puis constitution du corpus de specs du contrat public, fork d'un schéma taillé pour ce dépôt, et promotion du corpus.

## Ce que contient la PR

**1. Mise en place d'OpenSpec** (`chore(openspec)`)

`openspec/config.yaml` porte le contexte technique du projet et le contrat public à préserver. `.claude/` contient les 6 skills et 6 commandes générées par `openspec init`.

**2. Le changement cobaye : sortie du lecteur Flash des métadonnées** (`fix(post)`)

Les métadonnées OpenGraph déclaraient encore `player.swf` en `application/x-shockwave-flash`. Flash n'est plus exécuté depuis janvier 2021 : tout partage d'un lien du site produisait une carte sans lecteur, alors que l'embed HTML5 servi par `/post/:slug?embed` existe déjà et est exposé par `/oembed`.

- `og:video` pointe vers cet embed, `og:video:type` passe à `text/html`, dimensions alignées sur celles réellement servies (510×220).
- Ajout de `og:audio` pour les plateformes qui n'affichent pas d'iframe tierce.
- `og:type` passe de `video` à `music.song`.
- Les dimensions de l'embed deviennent des constantes partagées avec `executeOembed()` — exigence de la spec, pas refactor de confort.

**3. Le corpus de specs du contrat public existant** (`docs(openspec)`)

Cinq spécifications décrivant le comportement actuel, lu dans le code — le filet de non-régression pour une éventuelle sortie de Symfony 1.5 :

| Capacité | Couvre |
|---|---|
| `catalogue-morceaux` | Définition d'un morceau publiable (dont la fenêtre de deux heures sur `publish_on`), ordre, `/`, `/post/:slug`, `/posts/next`, `/posts/prev`, `/posts/random`, `/post/md5/:md5sum`, `/posts`, recherche |
| `formats-de-sortie` | Sélection par `format`, représentation JSON jsonapi.org, XSPF, Max/MSP |
| `flux-syndication` | Flux RSS 2.01 de `/posts/feed`, filtres, contenu des items, pièces jointes |
| `embarquement-oembed` | `/oembed` (JSON et XML) et le gabarit `?embed` |
| `desastres` | Déclenchement conditionnel et probabiliste, application des recettes, cumul |

Aucun comportement n'est modifié. Trois défauts rencontrés sont **consignés tels quels**, sans être corrigés : le gabarit `max` d'un morceau isolé réduit au mot `TODO` alors que le format est annoncé disponible ; le flux RSS qui charge chaque fichier audio entier en mémoire pour en déclarer la taille ; `/oembed` qui répond vide sur un `format` inconnu, sans erreur ni repli.

**4. Le schéma projet `musique-approximative`** (`feat(openspec)`)

Fork de `spec-driven`, retenu comme schéma par défaut. Deux écarts :

*Allégé* — l'artefact `design` sort du graphe, qui devient `proposition → specs → tâches`. Sur une application unique tenue par une seule personne, il faisait doublon avec la proposition ; l'essai grandeur nature l'avait déjà sauté. Un changement structurant décrit son approche dans une section dédiée de la proposition, et s'arrête pour discussion plutôt que de produire un document de plus.

*Francisé* — instructions, descriptions et gabarits sont en français. Seuls restent en anglais les repères que le parseur cherche littéralement, chacun documenté dans le schéma :

| Reste en anglais | Peut être francisé |
|---|---|
| `## Why`, `## What Changes`, `## Purpose` | `## Capacités`, `## Impact`, `### Hors périmètre` |
| `## ADDED / MODIFIED / REMOVED / RENAMED Requirements` | le nom de l'exigence après `Requirement:` |
| le préfixe `### Requirement:` | `#### Scénario : …` — tout titre de niveau 4 est compté |
| les mots-clés `SHALL` et `MUST` | `**QUAND**` / `**ALORS**` / `**ET**`, lus par personne |

Vérifié empiriquement par un changement d'essai depuis supprimé : validation stricte passée, et `openspec show --json` confirme que le scénario francisé est bien compté comme scénario, pas silencieusement ignoré.

Les règles de rédaction quittent `config.yaml` pour le schéma. Les laisser aux deux endroits aurait créé deux sources de vérité qui divergeraient — exactement le travers constaté sur la banque de mémoire.

**5. Réécriture des deux changements avec le schéma francisé** (`refactor(openspec)`)

Les deux changements basculent de `spec-driven` vers `musique-approximative` : scénarios en `#### Scénario :` avec QUAND, ALORS et ET, sections de proposition en Capacités. Ils affichent désormais leurs trois artefacts complets — le `design` fantôme qui bloquait les tâches a disparu du graphe.

Onze scénarios s'appuyaient implicitement sur la condition du scénario précédent et ne tenaient pas seuls ; chacun a reçu son propre QUAND, le schéma demandant des scénarios vérifiables un par un.

Contrôle de non-perte : les 75 scénarios des six capacités sont tous reconnus comme tels par l'outil après francisation. Le risque n'était pas l'échec de validation mais la disparition silencieuse — un `####` mal formé, et le scénario s'évapore sans un mot.

**6. Promotion du corpus dans `openspec/specs/`** (`docs(openspec)`)

Les six specs delta sont fusionnées vers le corpus principal : 31 exigences, 75 scénarios, plus aucun en-tête d'opération, tout sous une unique section `## Requirements`. `openspec validate --type spec --strict` passe sur les six.

**⚠️ La promotion a eu lieu avant la vérification manuelle**, sur décision explicite. Le corpus principal décrit donc un comportement lu dans le code et jamais observé en fonctionnement. C'est consigné dans la tâche 3.1 de `specifier-contrat-public-existant`, et une tâche 2.9 a été ajoutée : reporter dans `openspec/specs/` les corrections que la vérification imposera. Sans elle, corriger un scénario dans le changement laisserait le corpus mentir en silence, les deltas n'étant pas resynchronisées automatiquement.

**7. Deux correctifs CI** (`ci(trunk)`, `ci(pr)`)

- Exclusion de `.claude/**` et `openspec/**` de markdownlint et prettier : fichiers générés ou de structure imposée par le schéma, qui seraient reformatés à chaque `openspec update`. Les linters de sécurité restent actifs.
- `post-annotations: false` dans `pr.yml` — voir [le commentaire dédié](https://github.com/constructions-incongrues/musiqueapproximative/pull/89#issuecomment-5152451171). Le workflow était rouge sur **toutes** les PR depuis février 2026 à cause d'un défaut de `trunk-io/trunk-action@v1`, sans rapport avec cette branche. C'est le premier `pr.yml` vert du dépôt depuis.

## À faire avant fusion

Deux séries de vérifications manuelles restent ouvertes, faute d'environnement Docker lors de l'implémentation. Ce sont les seuls points bloquants côté contenu :

- `remplacer-embed-flash-opengraph`, section 4 : contrôler les métadonnées servies et le rendu de la carte de partage.
- `specifier-contrat-public-existant`, section 2 : exercer chaque scénario contre l'application, puis reporter les corrections dans `openspec/specs/` (tâche 2.9). Le comportement observé fait foi, pas la lecture du code.

## Retour d'expérience

**Ce qui marche**

- Le `context:` de `openspec/config.yaml` est le vrai apport. Injecté dans chaque instruction d'artefact, il a immédiatement révélé que `docs/memory-bank/README.adoc` avait dérivé : lecteur JW Player 5.9 annoncé alors que le site utilise jPlayer, et cinq routes documentées qui n'existent pas (`/random`, `/next`, `/prev`, `/md5/:md5sum`, `/feed.rss`). Écrire le contexte a produit le premier changement à faire.
- Les `rules:` par artefact sont réellement appliquées : la règle « pas de design sauf plusieurs modules touchés » a effectivement fait sauter `design.md`, avant que le fork ne retire l'artefact.
- Le fork de schéma tient ses promesses : les instructions sont de la configuration versionnée, modifiable et testable en quelques minutes.

**Frictions**

- **La typographie française casse le YAML.** `- Vérification manuelle : le projet…` est lu comme une clé de mapping. `openspec` avale ça en *warning* et ignore silencieusement **toute** la configuration — le premier changement a été créé sans contexte ni règles, sans que rien ne le signale.
- **La francisation est possible mais partielle**, et il faut lire le code du parseur pour savoir où s'arrête la marge de manœuvre. Le tableau ci-dessus est le résultat de cette lecture ; il est reporté dans le schéma pour ne pas avoir à la refaire.
- **Le format des artefacts est incompatible avec le lint du dépôt** : MD041 exige un titre `#` en première ligne, les templates ouvrent sur `##`.
- **`apply` n'a aucune notion de « fait mais non vérifié »**, qui est pourtant l'état par défaut sur ce projet sans tests. Le schéma francisé compense par une instruction explicite : une case cochée signifie vérifiée, jamais « probablement bon ».
- **`sync` ne laisse aucune trace dans le corpus** de ce qui a été promu et depuis quand. Rien ne distingue, dans `openspec/specs/`, une spec vérifiée d'une spec écrite d'après une lecture — d'où la tâche 2.9 ajoutée à la main.