### PR TITLE
Répare la fusion automatique — et rallume le scan de sécurité, éteint depuis six semaines

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -103,17 +103,25 @@ branches:
   - name: main
     protection:
       required_pull_request_reviews:
-        required_approving_review_count: 1
+        # Le dépôt n'a qu'un mainteneur, et GitHub interdit d'approuver sa propre pull
+        # request : exiger une approbation rendait toute fusion automatique impossible,
+        # et contraignait à fusionner à la main en contournant la règle. Le contrôle
+        # avant fusion repose désormais sur les contextes requis ci-dessous.
+        required_approving_review_count: 0
         dismiss_stale_reviews: true
         require_code_owner_reviews: false
 
       required_status_checks:
         strict: true
+        # Ces noms doivent correspondre au caractère près à ceux des jobs. Un contexte
+        # qui ne remonte jamais laisse la branche indéfiniment non fusionnable.
+        # `Trivy Scan` est à réintroduire une fois `security.yml` réactivé : GitHub l'a
+        # désactivé pour inactivité du dépôt le 24 juin 2026, et un workflow désactivé
+        # ne produit aucun contexte.
         contexts:
           - Validation du code
-          - Build Docker
+          - Build et Push Docker
           - Trunk Check
-          - Trivy Scan
 
       enforce_admins: true
       required_linear_history: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,10 +2,10 @@ name: Security Checks
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [main]
   schedule:
     - cron: 39 2 * * 3
 
@@ -18,7 +18,7 @@ jobs:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: Build
+    name: Trivy Scan
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -33,7 +33,7 @@ jobs:
         with:
           image-ref: docker.io/constructions-incongrues/musiqueapproximative:${{ github.sha }}
           format: template
-          template: '@/contrib/sarif.tpl'
+          template: "@/contrib/sarif.tpl"
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
 

--- a/openspec/changes/reparer-fusion-automatique/.openspec.yaml
+++ b/openspec/changes/reparer-fusion-automatique/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: musique-approximative
+created: 2026-08-01
+skip_specs: true

--- a/openspec/changes/reparer-fusion-automatique/proposal.md
+++ b/openspec/changes/reparer-fusion-automatique/proposal.md
@@ -1,0 +1,100 @@
+## Why
+
+Trois pull requests successives — #89, #90, #91 — ont été fusionnées à la main alors que
+la CI était intégralement verte et que la fusion automatique avait été armée. Elle ne se
+déclenche jamais, et `mergeable_state` reste indéfiniment à `blocked`.
+
+L'enquête révèle trois causes, dont une dépasse largement la question de la fusion.
+
+**Deux contextes requis ne remontent jamais.** La protection déclarée exige quatre
+contextes ; deux ne correspondent à rien :
+
+- `Build Docker` : le job s'appelle en réalité `Build et Push Docker`.
+- `Trivy Scan` : aucun job de ce nom. Le scan Trivy tourne dans un job nommé `Build`.
+
+Un contexte requis qui ne remonte pas reste en « Expected — Waiting for status to be
+reported », et la branche ne devient jamais fusionnable.
+
+**Le scan de sécurité ne tourne plus depuis six semaines.** C'est la découverte la plus
+sérieuse, et elle est indépendante de la fusion automatique. GitHub a désactivé quatre
+workflows pour inactivité du dépôt :
+
+| Workflow | Désactivé depuis | Conséquence |
+|---|---|---|
+| `security.yml` | 2026-06-24 | **Aucun scan Trivy, aucun envoi SARIF, sur aucune PR ni aucun push** |
+| `scorecard.yml` | 2026-06-27 | Plus d'analyse OpenSSF Scorecard |
+| `nightly.yml` | 2026-06-22 | Plus de contrôle Trunk nocturne |
+| `repomix.yml` | 2026-06-22 | Plus de génération de `repomix-output.xml` |
+
+La désactivation porte sur le workflow entier, pas seulement sur son déclencheur
+planifié : `security.yml` ne s'est donc exécuté sur aucune des trois pull requests
+récentes, alors qu'il déclare bien `pull_request`. Le badge « Security Scan » du README
+affiche un résultat figé au 11 avril.
+
+**La revue obligatoire est insatisfiable.** `required_approving_review_count: 1`, et
+GitHub interdit d'approuver sa propre pull request. Sur un dépôt tenu par une seule
+personne, aucune pull request ne peut donc jamais réunir son approbation.
+
+## What Changes
+
+- `Build Docker` devient `Build et Push Docker` dans les contextes requis, pour
+  correspondre au nom réel du job.
+- `Trivy Scan` est **retiré** des contextes requis. Exiger un contexte produit par un
+  workflow désactivé garantit un blocage permanent. Une tâche prévoit sa réintroduction
+  une fois le workflow réactivé et son exécution constatée.
+- Le job `build` de `security.yml`, jusqu'ici nommé `Build`, est renommé `Trivy Scan` :
+  c'est ce qu'il fait, et c'est le nom que la protection attendait.
+- `required_approving_review_count` passe de `1` à `0`. **C'est le seul arbitrage de
+  sécurité de ce changement**, détaillé ci-dessous.
+- Aucun comportement du site n'est touché. Le changement pose `skip_specs: true`.
+
+### L'arbitrage sur la revue
+
+Passer l'exigence à `0` retire le garde-fou humain avant fusion. Sur un dépôt à un seul
+mainteneur, ce garde-fou n'existait déjà pas : il ne produisait qu'un blocage contourné
+à la main à chaque fusion, ce qui est la pire des situations — la règle donne l'illusion
+d'un contrôle tout en étant systématiquement neutralisée.
+
+Ce qui subsiste comme protection : les contextes requis, l'historique linéaire,
+l'interdiction des poussées forcées et des suppressions de branche. Le contrôle passe de
+« quelqu'un a relu » à « la CI est verte », ce qui correspond à la réalité du dépôt.
+
+L'alternative, si tu préfères conserver l'exigence : accepter que chaque fusion reste
+manuelle, et ne plus armer la fusion automatique. C'est cohérent aussi, mais il faut
+alors retirer l'attente.
+
+### Hors périmètre
+
+- **La réactivation des quatre workflows désactivés.** Elle ne peut pas se faire par un
+  commit : c'est une action manuelle depuis l'onglet Actions, ou un appel à l'API
+  `PUT /actions/workflows/{id}/enable`. Une tâche la trace, mais elle t'incombe.
+- `strict: true` sur les contextes requis, qui impose en plus que la branche soit à jour
+  avec `main`. Ce n'est pas ce qui bloque aujourd'hui.
+- `enforce_admins: true`, que la réalité contredit déjà — trois fusions manuelles ont
+  abouti, ce qui serait impossible si la règle était appliquée telle que déclarée.
+- Le fond des workflows eux-mêmes : périodicité, étapes, versions d'actions.
+
+## Capacités
+
+### Nouvelles capacités
+
+Aucune.
+
+### Capacités modifiées
+
+Aucune. Le changement porte sur la configuration du dépôt et sur l'intégration continue,
+jamais sur le comportement du site. Aucune exigence du corpus ne bouge, d'où
+`skip_specs: true`.
+
+## Impact
+
+- `.github/settings.yml` : contextes requis et nombre d'approbations exigées.
+- `.github/workflows/security.yml` : nom du job.
+- Contrat public **inchangé**. Aucun fichier de `src/` n'est touché.
+
+**Réserve importante** : `.github/settings.yml` n'est qu'une déclaration, appliquée
+uniquement si l'app GitHub Settings est installée sur le dépôt. Un indice donne à penser
+qu'elle ne l'est pas : `enforce_admins: true` y figure, alors que trois fusions manuelles
+ont abouti sur des branches non fusionnables. Si l'app n'est pas installée, éditer ce
+fichier ne changera rien à la protection réelle, et il faudra reporter les mêmes
+corrections à la main dans Réglages → Branches. Une tâche de vérification le contrôle.

--- a/openspec/changes/reparer-fusion-automatique/tasks.md
+++ b/openspec/changes/reparer-fusion-automatique/tasks.md
@@ -1,0 +1,19 @@
+## 1. Alignement des contextes requis
+
+- [x] 1.1 Dans `.github/settings.yml`, remplacer le contexte `Build Docker` par `Build et Push Docker`, nom réel du job de `ci.yml`
+- [x] 1.2 Retirer `Trivy Scan` des contextes requis, le workflow qui le produirait étant désactivé
+- [x] 1.3 Renommer le job `build` de `.github/workflows/security.yml` de `Build` en `Trivy Scan`, pour que le nom décrive ce que fait le job et corresponde à ce que la protection attendait
+
+## 2. Exigence de revue
+
+- [x] 2.1 Passer `required_approving_review_count` de `1` à `0` dans `.github/settings.yml`
+
+## 3. Vérification manuelle
+
+- [ ] 3.1 Contrôler si l'app GitHub Settings est installée sur le dépôt. Si elle ne l'est pas, reporter à la main les corrections des sections 1 et 2 dans Réglages → Branches → `main` : c'est la protection réelle qui compte, pas le fichier
+- [ ] 3.2 Comparer la protection réellement appliquée à ce que déclare `settings.yml`, notamment `enforce_admins` : trois fusions manuelles ont abouti sur des branches non fusionnables, ce que cette règle interdirait
+- [ ] 3.3 Réactiver les quatre workflows désactivés pour inactivité — `security.yml`, `scorecard.yml`, `nightly.yml`, `repomix.yml` — depuis l'onglet Actions ou via `PUT /repos/:owner/:repo/actions/workflows/:id/enable`
+- [ ] 3.4 Sur la pull request de ce changement, vérifier qu'un check `Trivy Scan` apparaît bien une fois `security.yml` réactivé, et qu'il aboutit
+- [ ] 3.5 Une fois 3.4 constaté, réintroduire `Trivy Scan` dans les contextes requis de `.github/settings.yml`
+- [ ] 3.6 Ouvrir une pull request de contrôle, sans y toucher, et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le seul test qui valide l'objet de ce changement
+- [ ] 3.7 Vérifier que le badge « Security Scan » du README repasse au vert, son résultat étant figé au 11 avril 2026


### PR DESCRIPTION
Enquête sur les trois pull requests [#89](https://github.com/constructions-incongrues/musiqueapproximative/pull/89), [#90](https://github.com/constructions-incongrues/musiqueapproximative/pull/90) et [#91](https://github.com/constructions-incongrues/musiqueapproximative/pull/91), toutes fusionnées à la main alors que la CI était verte et la fusion automatique armée.

Premier changement issu du schéma `musique-approximative`. Il pose `skip_specs: true` : aucun comportement du site n'est en jeu.

## ⚠️ Le scan de sécurité ne tourne plus depuis six semaines

C'est la découverte la plus sérieuse, et elle dépasse la question de la fusion. GitHub a désactivé quatre workflows pour inactivité du dépôt :

| Workflow | Désactivé le | Conséquence |
|---|---|---|
| `security.yml` | 2026-06-24 | **Aucun scan Trivy, aucun envoi SARIF, sur aucune PR ni aucun push** |
| `scorecard.yml` | 2026-06-27 | Plus d'analyse OpenSSF Scorecard |
| `nightly.yml` | 2026-06-22 | Plus de contrôle Trunk nocturne |
| `repomix.yml` | 2026-06-22 | Plus de génération de `repomix-output.xml` |

La désactivation porte sur le **workflow entier**, pas seulement sur son déclencheur planifié. C'est pourquoi `security.yml` ne s'est exécuté sur aucune des trois PR récentes alors qu'il déclare bien `pull_request` : dernière exécution le 11 avril, sur une PR Dependabot. Le badge « Security Scan » du README affiche ce résultat figé depuis.

**Leur réactivation ne peut pas passer par un commit** — c'est une action manuelle depuis l'onglet Actions, ou `PUT /actions/workflows/{id}/enable`. Elle t'incombe, et c'est la tâche 3.3.

## Pourquoi la fusion automatique ne partait jamais

**Deux contextes requis ne remontaient rien.** La protection en exigeait quatre ; deux ne correspondaient à aucun job :

| Contexte requis | Réalité | Correction |
|---|---|---|
| `Validation du code` | ✅ existe | inchangé |
| `Trunk Check` | ✅ existe | inchangé |
| `Build Docker` | ❌ le job s'appelle `Build et Push Docker` | nom corrigé |
| `Trivy Scan` | ❌ le job s'appelle `Build`, et son workflow est désactivé | job renommé `Trivy Scan`, contexte **retiré** en attendant la réactivation |

Un contexte requis qui ne remonte jamais reste en « Expected — Waiting for status to be reported », et la branche n'est jamais fusionnable. Exiger un contexte produit par un workflow désactivé garantit un blocage permanent : d'où le retrait temporaire, avec réintroduction prévue en tâche 3.5 une fois le check constaté.

**L'exigence de revue était insatisfiable.** `required_approving_review_count: 1`, et GitHub interdit d'approuver sa propre pull request. Sur un dépôt à un seul mainteneur, aucune PR ne pouvait donc jamais réunir son approbation.

## Le seul arbitrage de sécurité

L'exigence d'approbation passe de `1` à `0`.

Ce garde-fou n'existait déjà pas en pratique : il ne produisait qu'un blocage contourné à la main à chaque fusion — la pire des situations, une règle qui donne l'illusion d'un contrôle tout en étant systématiquement neutralisée.

Ce qui subsiste : les contextes requis, l'historique linéaire, l'interdiction des poussées forcées et des suppressions de branche. Le contrôle passe de « quelqu'un a relu » à « la CI est verte », ce qui correspond à la réalité du dépôt.

L'alternative, si tu préfères garder l'exigence : accepter que chaque fusion reste manuelle, et ne plus armer la fusion automatique. C'est cohérent aussi — mais il faut alors retirer l'attente.

## Réserve sur la portée réelle de ce commit

`.github/settings.yml` n'est **qu'une déclaration**, appliquée uniquement si l'app GitHub Settings est installée sur le dépôt. Un indice donne à penser qu'elle ne l'est pas : `enforce_admins: true` y figure, alors que trois fusions manuelles ont abouti sur des branches non fusionnables — ce que cette règle interdirait.

Si l'app n'est pas installée, **éditer ce fichier ne changera rien à la protection réelle**, et il faudra reporter les mêmes corrections à la main dans Réglages → Branches. C'est la tâche 3.1, et c'est à vérifier avant toute autre chose.

## Divers

Le formatage de `security.yml` est corrigé au passage. L'écart préexistait, mais le fichier n'ayant jamais été modifié depuis l'activation du lint, il n'avait jamais été analysé — et l'aurait été dès que je le touchais.

## Ce qui reste à faire

Les sept tâches de la section 3, dont aucune ne peut être faite depuis un commit. La plus décisive est la 3.6 : ouvrir une PR de contrôle et vérifier que la fusion automatique se déclenche seule. C'est le seul test qui valide vraiment l'objet de ce changement.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_