### PR TITLE
Acte la réactivation du scan de sécurité et l'abandon des trois autres workflows

### DIFF
--- a/openspec/changes/reparer-fusion-automatique/proposal.md
+++ b/openspec/changes/reparer-fusion-automatique/proposal.md
@@ -65,9 +65,16 @@ alors retirer l'attente.
 
 ### Hors périmètre
 
-- **La réactivation des quatre workflows désactivés.** Elle ne peut pas se faire par un
-  commit : c'est une action manuelle depuis l'onglet Actions, ou un appel à l'API
-  `PUT /actions/workflows/{id}/enable`. Une tâche la trace, mais elle t'incombe.
+- **La réactivation des workflows désactivés.** Elle ne peut pas se faire par un commit :
+  c'est une action manuelle depuis l'onglet Actions, ou un appel à l'API
+  `PUT /actions/workflows/{id}/enable`. Une tâche la trace, mais elle incombe au
+  mainteneur.
+
+  Décision prise depuis : seul `security.yml` a été réactivé. `scorecard.yml`,
+  `nightly.yml` et `repomix.yml` restent délibérément éteints, le scan de sécurité étant
+  le seul qui importait. Leurs fichiers subsistent au dépôt sans jamais s'exécuter — un
+  changement dédié devrait décider de leur retrait, car un workflow présent mais inerte
+  induit en erreur qui le lit.
 - `strict: true` sur les contextes requis, qui impose en plus que la branche soit à jour
   avec `main`. Ce n'est pas ce qui bloque aujourd'hui.
 - `enforce_admins: true`, que la réalité contredit déjà — trois fusions manuelles ont

--- a/openspec/changes/reparer-fusion-automatique/tasks.md
+++ b/openspec/changes/reparer-fusion-automatique/tasks.md
@@ -12,8 +12,12 @@
 
 - [ ] 3.1 Contrôler si l'app GitHub Settings est installée sur le dépôt. Si elle ne l'est pas, reporter à la main les corrections des sections 1 et 2 dans Réglages → Branches → `main` : c'est la protection réelle qui compte, pas le fichier
 - [ ] 3.2 Comparer la protection réellement appliquée à ce que déclare `settings.yml`, notamment `enforce_admins` : trois fusions manuelles ont abouti sur des branches non fusionnables, ce que cette règle interdirait
-- [ ] 3.3 Réactiver les quatre workflows désactivés pour inactivité — `security.yml`, `scorecard.yml`, `nightly.yml`, `repomix.yml` — depuis l'onglet Actions ou via `PUT /repos/:owner/:repo/actions/workflows/:id/enable`
-- [ ] 3.4 Sur la pull request de ce changement, vérifier qu'un check `Trivy Scan` apparaît bien une fois `security.yml` réactivé, et qu'il aboutit
+- [x] 3.3 Réactiver `security.yml`, désactivé pour inactivité — fait, le workflow est repassé `active`. Le scan de sécurité peut de nouveau s'exécuter.
+      — `scorecard.yml`, `nightly.yml` et `repomix.yml` sont **délibérément laissés
+      éteints** : seul le scan de sécurité importait. Leurs fichiers restent au dépôt
+      sans jamais s'exécuter, ce qui est un piège pour qui les lira — leur retrait
+      mériterait un changement dédié.
+- [ ] 3.4 Vérifier qu'un check `Trivy Scan` apparaît sur une pull request et qu'il aboutit. Réactiver le workflow ne déclenche aucune exécution : il faut attendre le prochain push sur `main`, la prochaine pull request, ou le cron du mercredi
 - [ ] 3.5 Une fois 3.4 constaté, réintroduire `Trivy Scan` dans les contextes requis de `.github/settings.yml`
 - [ ] 3.6 Ouvrir une pull request de contrôle, sans y toucher, et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le seul test qui valide l'objet de ce changement
 - [ ] 3.7 Vérifier que le badge « Security Scan » du README repasse au vert, son résultat étant figé au 11 avril 2026


### PR DESCRIPTION
Mise à jour de l'avancement de `reparer-fusion-automatique`, ouvert par la [#92](https://github.com/constructions-incongrues/musiqueapproximative/pull/92). Aucun code, aucune configuration modifiée — seulement la fiche du changement et sa proposition.

## Ce qui est constaté

`security.yml` est **repassé `active`**. Le scan Trivy peut de nouveau s'exécuter, après six semaines d'interruption silencieuse. C'était le point le plus sérieux de toute la séquence.

Constaté par l'API, pas sur déclaration : le workflow était encore `disabled_inactivity` il y a quelques minutes.

## Ce qui est décidé

`scorecard.yml`, `nightly.yml` et `repomix.yml` restent **délibérément éteints**. Seul le scan de sécurité importait.

La décision est consignée dans la tâche 3.3 et dans la proposition, avec sa conséquence : **trois fichiers de workflow subsistent au dépôt sans jamais s'exécuter**. Qui lira `.github/workflows/scorecard.yml` en déduira raisonnablement qu'une analyse Scorecard tourne. Ce n'est plus le cas et ça ne le sera plus. Leur retrait mériterait un changement dédié — je ne l'ai pas ouvert, ce n'est pas ce qui a été demandé.

## Une précision utile

La tâche 3.4 était mal formulée. Réactiver un workflow **ne déclenche aucune exécution** : le check `Trivy Scan` n'apparaîtra qu'au prochain push sur `main`, à la prochaine pull request, ou au cron du mercredi. La dernière exécution de `security.yml` reste celle du 24 juin.

Cette PR étant elle-même une pull request, elle devrait produire ce premier check — ce qui vaudrait la tâche 3.4, et permettrait d'enchaîner sur la 3.5.

## Ce qui reste ouvert

| Tâche | Objet |
|---|---|
| 3.1 | L'app GitHub Settings est-elle installée ? Sans elle, `settings.yml` ne pilote rien |
| 3.2 | Comparer la protection réellement appliquée à ce qui est déclaré, `enforce_admins` en tête |
| 3.4 | Constater le check `Trivy Scan` |
| 3.5 | Le réintroduire dans les contextes requis, une fois constaté |
| 3.6 | Ouvrir une PR de contrôle et vérifier que la fusion automatique part seule |
| 3.7 | Le badge « Security Scan » du README, figé au 11 avril |

La 3.1 conditionne tout le reste : tant qu'on ne sait pas si la protection réelle a bougé, tester la fusion automatique n'apprendra rien.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_