### PR TITLE
Permet de lancer le scan de sécurité à la demande

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,10 @@ on:
     branches: [main]
   schedule:
     - cron: 39 2 * * 3
+  # Permet de lancer le scan à la demande. Indispensable pour diagnostiquer : GitHub
+  # désactive ce workflow après une période d'inactivité du dépôt, et sans déclencheur
+  # manuel on ne peut que constater l'absence d'exécution, jamais la provoquer.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/openspec/changes/declencher-manuellement-scan-securite/.openspec.yaml
+++ b/openspec/changes/declencher-manuellement-scan-securite/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: musique-approximative
+created: 2026-08-01
+skip_specs: true

--- a/openspec/changes/declencher-manuellement-scan-securite/proposal.md
+++ b/openspec/changes/declencher-manuellement-scan-securite/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+`security.yml` a été réactivé après six semaines de désactivation pour inactivité, et
+l'API GitHub le rapporte bien `active`. Pourtant il ne s'est toujours pas exécuté : sa
+dernière exécution reste celle du 24 juin, en cron.
+
+Trois événements auraient dû le déclencher depuis la réactivation — la fusion de la
+pull request #92 sur `main`, l'ouverture de la #93, puis sa fusion. Aucun n'a produit
+d'exécution, alors que le fichier déclare `push` et `pull_request` sur `main`, sans
+filtre de chemins.
+
+Deux hypothèses restent en présence, et rien dans le dépôt ne permet de les départager :
+la réactivation met du temps à se propager côté GitHub, ou elle n'a pas réellement pris
+malgré ce que rapporte l'API.
+
+Le workflow ne déclare aucun déclencheur manuel. Il est donc impossible de le lancer pour
+observer ce qui se passe : on ne peut qu'attendre un événement et constater son absence
+d'effet. C'est précisément ce qui manque pour trancher.
+
+## What Changes
+
+- `security.yml` déclare `workflow_dispatch`, ce qui permet de le lancer à la demande
+  depuis l'onglet Actions ou par l'API.
+- Rien d'autre ne change : ni les déclencheurs existants, ni les étapes, ni les
+  permissions, ni la périodicité du cron.
+
+Ce changement **ne répare rien par lui-même**. Il rend observable un état qui ne l'est
+pas : si un lancement manuel aboutit, la réactivation a pris et le problème est ailleurs,
+du côté des déclencheurs d'événements ; s'il échoue ou reste impossible, la réactivation
+n'a pas pris.
+
+Quatre workflows du dépôt déclarent déjà `workflow_dispatch` — `documentation.yml`,
+`nightly.yml`, `pr.yml` et `repomix.yml`. L'ajout suit une pratique établie, il
+n'introduit pas de convention nouvelle.
+
+### Hors périmètre
+
+- Les autres workflows dépourvus de déclencheur manuel : `ci.yml`, `scorecard.yml`,
+  `release-please.yml`, `auto-rebase.yml`, `cache_trunk.yaml`. Certains ne s'y prêtent
+  pas, et aucun ne pose le problème de diagnostic qui motive ce changement.
+- La réactivation de `scorecard.yml`, `nightly.yml` et `repomix.yml`, délibérément
+  laissés éteints.
+- Le sort des fichiers de ces trois workflows, présents au dépôt mais inertes.
+- Le fond du scan lui-même : image analysée, seuils de sévérité, envoi SARIF.
+- Les tâches encore ouvertes de `reparer-fusion-automatique`, qui suivent leur cours.
+
+## Capacités
+
+### Nouvelles capacités
+
+Aucune.
+
+### Capacités modifiées
+
+Aucune. Le changement porte sur l'intégration continue, jamais sur le comportement du
+site. Aucune exigence du corpus ne bouge, d'où `skip_specs: true`.
+
+## Impact
+
+- `.github/workflows/security.yml` : ajout d'un déclencheur.
+- Contrat public **inchangé**. Aucun fichier de `src/` n'est touché.
+- Aucune dépendance ajoutée, aucune migration, aucun changement de configuration du
+  dépôt.

--- a/openspec/changes/declencher-manuellement-scan-securite/tasks.md
+++ b/openspec/changes/declencher-manuellement-scan-securite/tasks.md
@@ -1,0 +1,12 @@
+## 1. Déclencheur manuel
+
+- [x] 1.1 Ajouter `workflow_dispatch` aux déclencheurs de `.github/workflows/security.yml`, sans toucher à `push`, `pull_request` ni `schedule`
+
+## 2. Vérification manuelle
+
+- [ ] 2.1 Une fois ce changement fusionné, ouvrir l'onglet Actions sur le workflow « Security Checks » et vérifier que le bouton « Run workflow » apparaît
+- [ ] 2.2 Lancer le workflow à la main sur `main` et observer le résultat. C'est le test qui départage les deux hypothèses : s'il s'exécute, la réactivation a pris et le défaut est du côté des déclencheurs d'événements ; s'il reste impossible à lancer, elle n'a pas pris
+- [ ] 2.3 Si le lancement aboutit, vérifier que le check porte bien le nom `Trivy Scan` — ce qui vaudra la tâche 3.4 de `reparer-fusion-automatique` et permettra de réintroduire le contexte requis
+- [ ] 2.4 Vérifier que les résultats remontent bien dans l'onglet Security du dépôt, l'envoi SARIF étant la finalité du workflow
+- [ ] 2.5 Vérifier si le badge « Security Scan » du README repasse au vert, son résultat étant figé au 11 avril 2026
+- [ ] 2.6 Sur la pull request suivante, vérifier si un check `Trivy Scan` apparaît de lui-même. C'est ce qui dira si le déclenchement automatique est rétabli, indépendamment du lancement manuel


### PR DESCRIPTION
Ajoute `workflow_dispatch` à `security.yml`. Une ligne de code, un changement OpenSpec avec `skip_specs` — aucun comportement du site n'est en jeu.

## Le problème

`security.yml` a été réactivé après six semaines de désactivation pour inactivité. L'API GitHub le rapporte `active`. **Et il ne s'exécute toujours pas** : sa dernière exécution reste celle du 24 juin, en cron.

Trois événements auraient dû le déclencher depuis la réactivation :

| Événement | Horodatage | Exécution ? |
|---|---|---|
| Fusion de la [#92](https://github.com/constructions-incongrues/musiqueapproximative/pull/92) sur `main` | ~18h50 UTC | ❌ |
| Ouverture de la [#93](https://github.com/constructions-incongrues/musiqueapproximative/pull/93) | 18h52 UTC | ❌ |
| Fusion de la #93 sur `main` | ~18h55 UTC | ❌ |

Ce que j'ai pu vérifier, et qui ne l'explique pas :

- l'état `active` est confirmé par l'API, mis à jour à 18h48 UTC ;
- le fichier sur `main` déclare bien `push` et `pull_request` sur `main`, **sans filtre de chemins** ;
- le job porte le nom attendu, `Trivy Scan`.

Deux hypothèses restent en présence, et rien dans le dépôt ne permet de les départager : la réactivation se propage lentement côté GitHub, ou elle n'a pas réellement pris malgré ce que rapporte l'API.

## Ce que ce changement fait — et ne fait pas

**Il ne répare rien.** Il rend observable un état qui ne l'est pas.

Le workflow ne déclarait aucun déclencheur manuel : on ne pouvait que subir l'absence d'exécution, jamais la provoquer. Avec `workflow_dispatch`, un lancement depuis l'onglet Actions tranche entre les deux hypothèses :

- **il s'exécute** → la réactivation a pris, le défaut est du côté des déclencheurs d'événements ;
- **il reste impossible à lancer** → la réactivation n'a pas pris, quoi qu'en dise l'API.

Rien d'autre ne bouge : ni `push`, ni `pull_request`, ni le cron du mercredi, ni les étapes, ni les permissions.

Quatre workflows du dépôt déclarent déjà `workflow_dispatch` — `documentation.yml`, `nightly.yml`, `pr.yml` et `repomix.yml`. L'ajout suit une pratique établie, il n'introduit pas de convention nouvelle.

## Après fusion

La tâche 2.2 est le test décisif : lancer le workflow à la main sur `main` et regarder ce qui se passe. Les tâches suivantes en découlent — nom du check, remontée SARIF dans l'onglet Security, badge du README, et surtout la 2.6 : voir si une pull request ultérieure déclenche le scan d'elle-même, ce qui dirait si l'automatisme est rétabli indépendamment du lancement manuel.

Le changement `reparer-fusion-automatique` reste ouvert en parallèle, à 5/11 tâches. Sa tâche 3.4 — constater le check `Trivy Scan` — sera satisfaite par la 2.3 d'ici.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_