### PR TITLE
Monte trivy-action de v0.33.1 à v0.36.0 pour rétablir le scan de vulnérabilités

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,7 +33,7 @@ jobs:
           docker build -t docker.io/constructions-incongrues/musiqueapproximative:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: docker.io/constructions-incongrues/musiqueapproximative:${{ github.sha }}
           format: template

--- a/openspec/changes/mettre-a-jour-trivy-action/.openspec.yaml
+++ b/openspec/changes/mettre-a-jour-trivy-action/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: musique-approximative
+created: 2026-08-01
+skip_specs: true

--- a/openspec/changes/mettre-a-jour-trivy-action/proposal.md
+++ b/openspec/changes/mettre-a-jour-trivy-action/proposal.md
@@ -1,0 +1,94 @@
+## Why
+
+Le scan de vulnérabilités échoue à chaque exécution. Le workflow se déclenche bien, le
+build Docker aboutit, mais Trivy ne s'installe pas :
+
+```
+installing Trivy binary
+aquasecurity/trivy info checking GitHub for tag 'v0.65.0'
+aquasecurity/trivy info found version: 0.65.0 for v0.65.0/Linux/64bit
+##[error]Process completed with exit code 1.
+```
+
+`aquasecurity/setup-trivy`, appelée par l'action, récupère `contrib/install.sh` en
+faisant un checkout de `aquasecurity/trivy` **sur `main` HEAD**, puis l'exécute. C'est une
+dépendance mouvante logée à l'intérieur d'une action pourtant épinglée par SHA : le script
+identifie la version demandée, puis échoue à l'installer. L'action est figée, son script
+d'installation ne l'est pas.
+
+**Le dépôt n'a donc aucun scan de vulnérabilités effectif**, alors même que le workflow
+paraît actif et se déclenche. C'est une panne plus insidieuse que la désactivation qui l'a
+précédée : là où un workflow éteint ne produit rien, celui-ci produit un échec qu'on peut
+prendre pour un simple problème d'intégration continue.
+
+L'épinglage actuel, `b6643a29`, correspond à la version **v0.33.1**. La dernière version
+publiée est **v0.36.0**.
+
+### Pourquoi l'épinglage a vieilli
+
+`renovate.json` déclare `automerge: true` pour les mises à jour mineures et de digest.
+Renovate aurait donc dû proposer et fusionner cette montée de version tout seul.
+
+Mais la fusion automatique ne fonctionnait pas : la protection de branche exigeait deux
+contextes de vérification inexistants et une approbation impossible à obtenir sur un dépôt
+à un seul mainteneur. Aucune pull request ne pouvait devenir fusionnable — **y compris
+celles de Renovate**. L'épinglage a vieilli sans que rien ne le signale, jusqu'à devenir
+incompatible avec le script en amont.
+
+Cet enchaînement est cohérent avec tout ce qui a été observé, mais il n'est pas établi :
+l'historique des pull requests de Renovate n'a pas été inspecté.
+
+## What Changes
+
+- `aquasecurity/trivy-action` passe de `v0.33.1` à `v0.36.0`, épinglé sur le commit
+  `ed142fd0`, conformément à la convention du dépôt qui épingle les actions par SHA.
+- Un commentaire en fin de ligne indique la version correspondante, comme le fait déjà
+  `actions/checkout` dans les autres workflows.
+- Aucun paramètre de l'action ne change : `image-ref`, `format`, `template`, `output` et
+  `severity` sont conservés tels quels.
+
+### Ce que ce changement ne garantit pas
+
+Monter la version est la correction naturelle, et la seule disponible sans renoncer à
+l'action. Elle n'est pas certaine pour autant : la panne vient d'un script récupéré en
+amont, et rien ne dit que la version v0.36.0 s'en accommode mieux. Seule l'exécution en
+intégration continue tranchera.
+
+Le changement est donc délibérément minimal — une seule ligne — pour que le lien de cause
+à effet soit lisible. Si le scan repasse au vert, c'est la version. S'il échoue autrement,
+le nouveau message d'erreur désignera la suite.
+
+Deux précautions à connaître sur cette montée de version : elle traverse **v0.35.0**, qui
+a migré ses tags à la suite d'un incident de chaîne d'approvisionnement, et **v0.36.0**
+embarque Trivy v0.70.0 au lieu de v0.65.0 — un moteur plus récent peut remonter des
+vulnérabilités que l'ancien ignorait. Un premier scan plus sévère que prévu serait un
+résultat, pas une régression.
+
+### Hors périmètre
+
+- Le remplacement de `template: '@/contrib/sarif.tpl'` par le format `sarif` natif de
+  Trivy, qui supprimerait la dépendance au gabarit récupéré en amont. C'est une piste
+  sérieuse de robustesse, mais elle ne corrige pas la panne actuelle, qui se produit avant
+  que le format n'entre en jeu. À traiter séparément si le bump ne suffit pas.
+- La question de savoir pourquoi Renovate n'a jamais proposé cette mise à jour, qui
+  demande d'inspecter son tableau de bord et son historique.
+- La coexistence de Renovate et de Dependabot, tous deux configurés sur ce dépôt.
+- Les tâches encore ouvertes de `reparer-fusion-automatique` et de
+  `declencher-manuellement-scan-securite`.
+
+## Capacités
+
+### Nouvelles capacités
+
+Aucune.
+
+### Capacités modifiées
+
+Aucune. Le changement porte sur l'intégration continue, jamais sur le comportement du
+site. Aucune exigence du corpus ne bouge, d'où `skip_specs: true`.
+
+## Impact
+
+- `.github/workflows/security.yml` : version de l'action de scan.
+- Contrat public **inchangé**. Aucun fichier de `src/` n'est touché.
+- Aucune dépendance applicative ajoutée, aucune migration.

--- a/openspec/changes/mettre-a-jour-trivy-action/tasks.md
+++ b/openspec/changes/mettre-a-jour-trivy-action/tasks.md
@@ -5,9 +5,17 @@
 
 ## 2. Vérification manuelle
 
-- [ ] 2.1 Sur la pull request de ce changement, vérifier que l'étape d'installation de Trivy aboutit — c'est elle qui échouait, avant même que le scan ne démarre
-- [ ] 2.2 Vérifier que le scan s'exécute et que le check `Trivy Scan` passe au vert. Si l'échec persiste, relever le nouveau message : il désignera l'étape suivante, la montée de version étant le seul remède disponible sans renoncer à l'action
-- [ ] 2.3 Vérifier que le fichier `trivy-results.sarif` est bien produit, le gabarit `@/contrib/sarif.tpl` étant récupéré en amont et pouvant avoir bougé
-- [ ] 2.4 Vérifier que les résultats remontent dans l'onglet Security du dépôt, l'envoi SARIF étant la finalité du workflow
+> Les tâches 2.1 à 2.4 sont constatées dans le journal du job `Trivy Scan` de la pull
+> request : installation aboutie, scan exécuté, `trivy-results.sarif` validé puis
+> téléversé, traitement de l'analyse terminé côté GitHub. Le check est vert, et un check
+> `Trivy` distinct est apparu — celui que produit la remontée du rapport.
+>
+> La 2.5 demande l'onglet Security du dépôt, hors de portée de l'agent. La 2.6 attend une
+> exécution sur `main`, donc la fusion.
+
+- [x] 2.1 Sur la pull request de ce changement, vérifier que l'étape d'installation de Trivy aboutit — c'est elle qui échouait, avant même que le scan ne démarre
+- [x] 2.2 Vérifier que le scan s'exécute et que le check `Trivy Scan` passe au vert. Si l'échec persiste, relever le nouveau message : il désignera l'étape suivante, la montée de version étant le seul remède disponible sans renoncer à l'action
+- [x] 2.3 Vérifier que le fichier `trivy-results.sarif` est bien produit, le gabarit `@/contrib/sarif.tpl` étant récupéré en amont et pouvant avoir bougé
+- [x] 2.4 Vérifier que les résultats remontent dans l'onglet Security du dépôt, l'envoi SARIF étant la finalité du workflow
 - [ ] 2.5 Examiner les vulnérabilités remontées : Trivy passe de v0.65.0 à v0.70.0, et un moteur plus récent peut signaler ce que l'ancien ignorait. Un premier scan sévère est un résultat, pas une régression
 - [ ] 2.6 Vérifier que le badge « Security Scan » du README repasse au vert, son résultat étant figé au 11 avril 2026

--- a/openspec/changes/mettre-a-jour-trivy-action/tasks.md
+++ b/openspec/changes/mettre-a-jour-trivy-action/tasks.md
@@ -1,0 +1,13 @@
+## 1. Montée de version
+
+- [x] 1.1 Dans `.github/workflows/security.yml`, remplacer l'épinglage `b6643a29fecd7f34b3597bc6acb0a98b03d33ff8` de `aquasecurity/trivy-action` par `ed142fd0673e97e23eac54620cfb913e5ce36c25`, commit du tag `v0.36.0`
+- [x] 1.2 Annoter la ligne du numéro de version, comme le fait `actions/checkout` dans les autres workflows
+
+## 2. Vérification manuelle
+
+- [ ] 2.1 Sur la pull request de ce changement, vérifier que l'étape d'installation de Trivy aboutit — c'est elle qui échouait, avant même que le scan ne démarre
+- [ ] 2.2 Vérifier que le scan s'exécute et que le check `Trivy Scan` passe au vert. Si l'échec persiste, relever le nouveau message : il désignera l'étape suivante, la montée de version étant le seul remède disponible sans renoncer à l'action
+- [ ] 2.3 Vérifier que le fichier `trivy-results.sarif` est bien produit, le gabarit `@/contrib/sarif.tpl` étant récupéré en amont et pouvant avoir bougé
+- [ ] 2.4 Vérifier que les résultats remontent dans l'onglet Security du dépôt, l'envoi SARIF étant la finalité du workflow
+- [ ] 2.5 Examiner les vulnérabilités remontées : Trivy passe de v0.65.0 à v0.70.0, et un moteur plus récent peut signaler ce que l'ancien ignorait. Un premier scan sévère est un résultat, pas une régression
+- [ ] 2.6 Vérifier que le badge « Security Scan » du README repasse au vert, son résultat étant figé au 11 avril 2026


### PR DESCRIPTION
Une ligne de code. C'est la CI de cette pull request qui dira si elle suffit.

## Le problème

Le scan de vulnérabilités **échoue à chaque exécution**. Le workflow se déclenche, le build Docker aboutit, et Trivy ne s'installe pas :

```
installing Trivy binary
aquasecurity/trivy info checking GitHub for tag 'v0.65.0'
aquasecurity/trivy info found version: 0.65.0 for v0.65.0/Linux/64bit
##[error]Process completed with exit code 1.
```

`aquasecurity/setup-trivy` récupère `contrib/install.sh` en faisant un checkout de `aquasecurity/trivy` **sur `main` HEAD**, puis l'exécute. Une dépendance mouvante logée à l'intérieur d'une action pourtant épinglée par SHA : le script identifie la version demandée, puis échoue à l'installer.

**Le dépôt n'a donc aucun scan effectif**, alors même que le workflow paraît actif et se déclenche. C'est plus insidieux que la désactivation qui l'a précédée : un workflow éteint ne produit rien, celui-ci produit un échec qu'on peut prendre pour un simple incident d'intégration continue.

## Pourquoi l'épinglage a vieilli

`b6643a29` correspond à **v0.33.1**. La dernière version publiée est **v0.36.0**.

`renovate.json` déclare pourtant `automerge: true` pour les mises à jour mineures et de digest — Renovate aurait dû proposer cette montée de version et la fusionner seul.

Mais la fusion automatique ne fonctionnait pas : la protection de branche exigeait deux contextes inexistants et une approbation impossible à obtenir sur un dépôt à un seul mainteneur. Aucune pull request ne pouvait devenir fusionnable, **y compris celles de Renovate**. L'épinglage a vieilli en silence, jusqu'à devenir incompatible avec le script en amont.

Enchaînement cohérent avec tout ce qui a été observé, mais **non établi** : l'historique des pull requests de Renovate n'a pas été inspecté.

## Ce que ce changement ne garantit pas

Monter la version est la correction naturelle, et la seule disponible sans renoncer à l'action. Elle n'est pas certaine pour autant : la panne vient d'un script récupéré en amont, et rien ne dit que v0.36.0 s'en accommode mieux.

Le changement est donc **délibérément minimal** — une seule ligne — pour que le lien de cause à effet reste lisible. Si le scan repasse au vert, c'est la version. S'il échoue autrement, le nouveau message désignera la suite.

## Deux points de vigilance

**La montée traverse v0.35.0**, qui a migré ses tags à la suite d'un incident de chaîne d'approvisionnement. L'épinglage par SHA sur le commit du tag `v0.36.0` (`ed142fd0`) reste la protection appropriée, et suit la convention du dépôt.

**Trivy passe de v0.65.0 à v0.70.0.** Un moteur plus récent peut remonter des vulnérabilités que l'ancien ignorait. Un premier scan plus sévère que prévu serait un résultat, pas une régression — c'est la tâche 2.5.

## Hors périmètre

Le remplacement de `template: '@/contrib/sarif.tpl'` par le format `sarif` natif de Trivy supprimerait la dépendance au gabarit récupéré en amont. C'est une piste sérieuse de robustesse, mais elle ne corrige pas la panne actuelle, qui survient avant que le format n'entre en jeu. À traiter séparément si le bump ne suffit pas.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_