### PR TITLE
Rend settings.yml exact, en vue de son application par l'app GitHub Settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -114,16 +114,21 @@ branches:
       required_status_checks:
         strict: true
         # Ces noms doivent correspondre au caractère près à ceux des jobs. Un contexte
-        # qui ne remonte jamais laisse la branche indéfiniment non fusionnable.
-        # `Trivy Scan` est à réintroduire une fois `security.yml` réactivé : GitHub l'a
-        # désactivé pour inactivité du dépôt le 24 juin 2026, et un workflow désactivé
-        # ne produit aucun contexte.
+        # qui ne remonte jamais laisse la branche indéfiniment non fusionnable, sans
+        # message d'erreur : il reste simplement « en attente ».
         contexts:
           - Validation du code
           - Build et Push Docker
           - Trunk Check
+          - Trivy Scan
 
-      enforce_admins: true
+      # Volontairement à false. Un contexte requis peut cesser de remonter sans prévenir
+      # — job renommé, workflow désactivé pour inactivité, action cassée en amont : les
+      # trois se sont produits sur ce dépôt. Avec un seul mainteneur, qui ne peut pas
+      # approuver ses propres pull requests, interdire le contournement administrateur ne
+      # laisserait aucune issue et verrouillerait le dépôt jusqu'à correction manuelle de
+      # la protection.
+      enforce_admins: false
       required_linear_history: true
       allow_force_pushes: false
       allow_deletions: false

--- a/openspec/changes/appliquer-settings-yml-par-lapp/.openspec.yaml
+++ b/openspec/changes/appliquer-settings-yml-par-lapp/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: musique-approximative
+created: 2026-08-01
+skip_specs: true

--- a/openspec/changes/appliquer-settings-yml-par-lapp/proposal.md
+++ b/openspec/changes/appliquer-settings-yml-par-lapp/proposal.md
@@ -1,0 +1,79 @@
+## Why
+
+`.github/settings.yml` décrit la configuration du dépôt — options de fusion, seize
+libellés, protection de la branche `main` — mais rien ne l'applique : l'app GitHub
+Settings n'est pas installée. Le fichier est purement décoratif, et les corrections de
+protection fusionnées par la pull request #92 n'ont eu aucun effet.
+
+La décision est prise de l'installer, pour que ce fichier devienne la source de vérité :
+la configuration du dépôt sera alors versionnée, relue en pull request, et cessera de
+diverger en silence.
+
+Cette décision inverse la charge du risque. Aujourd'hui le fichier ment sans conséquence ;
+demain il sera appliqué. **Toute erreur qu'il contient deviendra la configuration
+réelle.** Il doit donc être exact avant l'installation, pas après.
+
+## What Changes
+
+- `Trivy Scan` réintègre les contextes de vérification requis. Il en avait été retiré
+  parce que son workflow était désactivé et ne produisait aucun contexte ; le workflow est
+  réactivé, le job renommé, et le check a été constaté vert sur la pull request #96.
+- Les commentaires qui décrivaient un état transitoire — workflow désactivé, contexte à
+  réintroduire — sont réécrits pour décrire la configuration voulue.
+- `enforce_admins` passe de `true` à `false`. **C'est le seul arbitrage de ce changement**,
+  détaillé ci-dessous.
+- Aucune autre valeur ne bouge : options de fusion, libellés, historique linéaire,
+  interdiction des poussées forcées et des suppressions.
+
+### L'arbitrage sur `enforce_admins`
+
+Le fichier déclare `enforce_admins: true`, qui interdit à quiconque, administrateurs
+compris, de fusionner une branche ne satisfaisant pas la protection. Tant que rien
+n'appliquait le fichier, cette ligne était sans effet — c'est d'ailleurs ce qui a permis
+de fusionner sept pull requests à la main pendant que la protection était cassée.
+
+L'appliquer telle quelle serait imprudent sur ce dépôt. La séquence qui précède a montré
+qu'un contexte requis peut cesser de remonter sans prévenir : un job renommé, un workflow
+désactivé pour inactivité, une action dont l'installation casse en amont. Chacun de ces
+incidents a rendu toute pull request non fusionnable. Avec `enforce_admins: true` et un
+seul mainteneur, il n'existerait alors **aucune issue** : ni approbation possible, ni
+contournement administrateur. Le dépôt serait verrouillé jusqu'à modification manuelle de
+la protection.
+
+Le passer à `false` conserve la protection comme règle de fonctionnement normal, tout en
+gardant une sortie de secours pour son mainteneur. C'est la configuration qui correspond à
+la réalité observée, puisque c'est ainsi que le dépôt a fonctionné jusqu'ici.
+
+### Hors périmètre
+
+- **L'installation de l'app elle-même**, qui se fait depuis `github.com/apps/settings` et
+  demande des droits d'administration sur le dépôt. Elle incombe au mainteneur, et une
+  tâche la trace.
+- La réintroduction du contexte `Trivy Scan` dans la protection **réelle**, qui n'a de
+  sens qu'une fois l'app installée : c'est elle qui appliquera le fichier.
+- Le sort de `scorecard.yml`, `nightly.yml` et `repomix.yml`, délibérément laissés éteints,
+  dont les fichiers subsistent sans jamais s'exécuter.
+- Les seize libellés déclarés, conservés tels quels — leur revue est un autre sujet.
+
+## Capacités
+
+### Nouvelles capacités
+
+Aucune.
+
+### Capacités modifiées
+
+Aucune. Le changement porte sur la configuration du dépôt, jamais sur le comportement du
+site. Aucune exigence du corpus ne bouge, d'où `skip_specs: true`.
+
+## Impact
+
+- `.github/settings.yml` : contextes requis, `enforce_admins`, commentaires.
+- Contrat public **inchangé**. Aucun fichier de `src/` n'est touché.
+
+**À savoir avant d'installer** : l'app applique **l'intégralité** du fichier, pas
+seulement la protection de branche. Les seize libellés y sont déclarés, ainsi que les
+options de fusion et les métadonnées du dépôt — description, page d'accueil, sujets. Tout
+ce qui diffère aujourd'hui de ce que déclare le fichier sera aligné sur lui. Une tâche
+prévoit de comparer les trois sections aux réglages réels avant de déclencher
+l'installation.

--- a/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
+++ b/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
@@ -1,0 +1,24 @@
+## 1. Mise en exactitude du fichier
+
+- [x] 1.1 Réintroduire `Trivy Scan` dans les contextes de vérification requis de `.github/settings.yml`
+- [x] 1.2 Réécrire les commentaires qui décrivaient un état transitoire — workflow désactivé, contexte à réintroduire — pour qu'ils décrivent la configuration voulue
+- [x] 1.3 Passer `enforce_admins` de `true` à `false`, et documenter la raison en commentaire : sans issue de secours, un contexte requis qui cesse de remonter verrouillerait le dépôt
+
+## 2. Avant l'installation
+
+> Ces vérifications sont à faire **avant** de déclencher l'installation, pas après.
+> L'app applique l'intégralité du fichier : tout écart entre ce qu'il déclare et les
+> réglages actuels sera résolu en faveur du fichier.
+
+- [ ] 2.1 Comparer la section `repository` aux réglages réels : description, page d'accueil, sujets, options de fusion, suppression de branche après fusion
+- [ ] 2.2 Comparer les seize libellés déclarés à ceux qui existent, en repérant ceux qui seraient créés, renommés ou recolorés
+- [ ] 2.3 Comparer la section `branches` à la protection réellement appliquée sur `main`, et relever les écarts
+- [ ] 2.4 Décider, pour chaque écart relevé, si c'est le fichier ou le réglage qui a raison — et corriger le fichier le cas échéant
+
+## 3. Installation et vérification
+
+- [ ] 3.1 Installer l'app GitHub Settings depuis `github.com/apps/settings`, en la limitant au dépôt `musiqueapproximative`
+- [ ] 3.2 Vérifier que la protection de `main` reflète désormais le fichier : quatre contextes requis, zéro approbation exigée, historique linéaire
+- [ ] 3.3 Vérifier que les réglages du dépôt et les libellés n'ont pas été altérés de façon inattendue
+- [ ] 3.4 Ouvrir une pull request de contrôle, sans y toucher, et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le test qui clôt `reparer-fusion-automatique`
+- [ ] 3.5 Modifier une valeur du fichier dans une pull request et vérifier qu'elle est appliquée après fusion : c'est ce qui distingue une source de vérité d'un document décoratif

--- a/openspec/changes/reparer-fusion-automatique/proposal.md
+++ b/openspec/changes/reparer-fusion-automatique/proposal.md
@@ -99,9 +99,19 @@ jamais sur le comportement du site. Aucune exigence du corpus ne bouge, d'où
 - `.github/workflows/security.yml` : nom du job.
 - Contrat public **inchangé**. Aucun fichier de `src/` n'est touché.
 
-**Réserve importante** : `.github/settings.yml` n'est qu'une déclaration, appliquée
-uniquement si l'app GitHub Settings est installée sur le dépôt. Un indice donne à penser
-qu'elle ne l'est pas : `enforce_admins: true` y figure, alors que trois fusions manuelles
-ont abouti sur des branches non fusionnables. Si l'app n'est pas installée, éditer ce
-fichier ne changera rien à la protection réelle, et il faudra reporter les mêmes
-corrections à la main dans Réglages → Branches. Une tâche de vérification le contrôle.
+**Réserve importante, depuis confirmée** : `.github/settings.yml` n'est qu'une
+déclaration, appliquée uniquement si l'app GitHub Settings est installée sur le dépôt.
+Un indice donnait à penser qu'elle ne l'était pas — `enforce_admins: true` y figure,
+alors que trois fusions manuelles ont abouti sur des branches non fusionnables.
+
+Vérification faite : **l'app n'est pas installée**. Éditer ce fichier n'a donc rien changé
+à la protection réelle. Les corrections des sections 1 et 2 sont restées lettre morte, et
+la fusion automatique demeure cassée pour les raisons décrites plus haut. Elles doivent
+être reportées à la main dans Réglages → Branches, ce que trace la tâche 3.2.
+
+Ce constat désigne un problème plus large que ce changement : `settings.yml` décrit une
+configuration qui n'est pas celle du dépôt. C'est le troisième artefact de ce genre
+rencontré ici, après `docs/memory-bank/README.adoc` — supprimé pour avoir dérivé — et les
+workflows désactivés dont les fichiers subsistent. Décider du sort de `settings.yml`
+— l'appliquer en installant l'app, le supprimer, ou le marquer explicitement comme
+indicatif — dépasse le périmètre de ce changement et mérite le sien.

--- a/openspec/changes/reparer-fusion-automatique/tasks.md
+++ b/openspec/changes/reparer-fusion-automatique/tasks.md
@@ -10,14 +10,22 @@
 
 ## 3. Vérification manuelle
 
-- [ ] 3.1 Contrôler si l'app GitHub Settings est installée sur le dépôt. Si elle ne l'est pas, reporter à la main les corrections des sections 1 et 2 dans Réglages → Branches → `main` : c'est la protection réelle qui compte, pas le fichier
-- [ ] 3.2 Comparer la protection réellement appliquée à ce que déclare `settings.yml`, notamment `enforce_admins` : trois fusions manuelles ont abouti sur des branches non fusionnables, ce que cette règle interdirait
+- [x] 3.1 Contrôler si l'app GitHub Settings est installée sur le dépôt
+      — **elle ne l'est pas.** `settings.yml` ne pilote donc rien : les corrections des
+      sections 1 et 2, fusionnées par la PR #92, n'ont modifié qu'un fichier décoratif.
+      La protection réelle est inchangée, et la fusion automatique reste cassée pour les
+      mêmes raisons qu'au départ. Elles restent à reporter à la main.
+- [ ] 3.2 Reporter à la main dans Réglages → Branches → `main` les corrections que `settings.yml` déclare sans les appliquer : contextes requis alignés sur `Validation du code`, `Build et Push Docker` et `Trunk Check`, et nombre d'approbations exigées ramené à zéro
+- [ ] 3.3bis Relever au passage la protection réellement appliquée, notamment `enforce_admins` : trois fusions manuelles ont abouti sur des branches non fusionnables, ce que cette règle interdirait si elle était active
 - [x] 3.3 Réactiver `security.yml`, désactivé pour inactivité — fait, le workflow est repassé `active`. Le scan de sécurité peut de nouveau s'exécuter.
       — `scorecard.yml`, `nightly.yml` et `repomix.yml` sont **délibérément laissés
       éteints** : seul le scan de sécurité importait. Leurs fichiers restent au dépôt
       sans jamais s'exécuter, ce qui est un piège pour qui les lira — leur retrait
       mériterait un changement dédié.
-- [ ] 3.4 Vérifier qu'un check `Trivy Scan` apparaît sur une pull request et qu'il aboutit. Réactiver le workflow ne déclenche aucune exécution : il faut attendre le prochain push sur `main`, la prochaine pull request, ou le cron du mercredi
-- [ ] 3.5 Une fois 3.4 constaté, réintroduire `Trivy Scan` dans les contextes requis de `.github/settings.yml`
+- [x] 3.4 Vérifier qu'un check `Trivy Scan` apparaît sur une pull request et qu'il aboutit
+      — constaté sur la PR #96 : le check est apparu de lui-même et a abouti, une fois
+      `trivy-action` montée en version. Le déclenchement automatique fonctionne, avec un
+      délai de propagation d'une dizaine de minutes après la réactivation du workflow.
+- [ ] 3.5 Une fois la protection réelle corrigée (3.2), y réintroduire `Trivy Scan` parmi les contextes requis, et le remettre dans `.github/settings.yml` pour que le fichier reste fidèle
 - [ ] 3.6 Ouvrir une pull request de contrôle, sans y toucher, et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le seul test qui valide l'objet de ce changement
 - [ ] 3.7 Vérifier que le badge « Security Scan » du README repasse au vert, son résultat étant figé au 11 avril 2026


### PR DESCRIPTION
Deux commits. Le premier acte que `.github/settings.yml` ne pilote rien ; le second le rend exact, la décision ayant été prise d'installer l'app qui l'appliquera.

## Le constat

**L'app GitHub Settings n'est pas installée.** `settings.yml` est purement déclaratif.

Les corrections de protection de branche fusionnées par la [#92](https://github.com/constructions-incongrues/musiqueapproximative/pull/92) — contextes requis alignés sur les noms réels des jobs, approbations ramenées à zéro — **n'ont modifié qu'un fichier sans effet**. La protection réelle est inchangée, et la fusion automatique reste cassée pour exactement les raisons décrites au départ.

C'était la réserve que je posais alors, fondée sur un indice : `enforce_admins: true` y figure alors que sept fusions manuelles ont abouti sur des branches non fusionnables. La vérification la confirme.

Au passage, tâche 3.4 de `reparer-fusion-automatique` satisfaite : le check `Trivy Scan` est apparu de lui-même sur la [#96](https://github.com/constructions-incongrues/musiqueapproximative/pull/96) et a abouti.

## La décision : installer l'app

Le fichier devient la source de vérité. La configuration du dépôt sera versionnée, relue en pull request, et cessera de diverger en silence.

**Cette décision inverse la charge du risque.** Aujourd'hui le fichier ment sans conséquence ; demain il sera appliqué, et toute erreur qu'il contient deviendra la configuration réelle. D'où ce second commit, qui le met en exactitude **avant** l'installation.

| Réglage | Avant | Après | Pourquoi |
|---|---|---|---|
| Contextes requis | 3 | 4, avec `Trivy Scan` | Le workflow est réactivé, le job renommé, le check constaté vert |
| `enforce_admins` | `true` | `false` | Voir ci-dessous |
| Commentaires | Décrivaient un état transitoire | Décrivent la configuration voulue | — |

## Le seul arbitrage : `enforce_admins`

Interdire le contournement administrateur serait imprudent sur ce dépôt.

La séquence récente a montré qu'un contexte requis peut cesser de remonter sans prévenir. Les trois cas se sont produits ici, en quelques heures :

- un job renommé (`Build Docker` → `Build et Push Docker`) ;
- un workflow désactivé pour inactivité (`security.yml`, six semaines) ;
- une action dont l'installation casse en amont (`trivy-action` v0.33.1).

Chacun a rendu toute pull request non fusionnable. Avec `enforce_admins: true` et un seul mainteneur — qui ne peut pas approuver ses propres pull requests — il n'existerait alors **aucune issue** : ni approbation, ni contournement. Le dépôt serait verrouillé jusqu'à modification manuelle de la protection.

`false` conserve la protection comme règle de fonctionnement normal, tout en gardant une sortie de secours. C'est aussi la configuration qui décrit la réalité observée : sept fusions manuelles l'attestent.

## ⚠️ À faire avant d'installer

L'app applique **l'intégralité du fichier**, pas seulement la protection de branche. Il déclare aussi les métadonnées du dépôt — description, page d'accueil, sujets, options de fusion — et seize libellés. Tout ce qui diffère aujourd'hui sera aligné sur le fichier.

La section 2 des tâches prévoit de comparer les trois sections aux réglages réels et de trancher, écart par écart, qui a raison du fichier ou du réglage. **C'est à faire avant de déclencher l'installation, pas après.**

L'installation elle-même se fait depuis `github.com/apps/settings` et demande des droits d'administration : elle t'incombe.

## Le motif qui se répète

`settings.yml` décrivait une configuration qui n'est pas celle du dépôt. C'est le **troisième artefact de ce genre** rencontré dans cette séquence :

| Artefact | Ce qu'il paraissait être | Ce qu'il était |
|---|---|---|
| `docs/memory-bank/README.adoc` | La description du projet | Cinq routes inexistantes, un lecteur abandonné — supprimé |
| `scorecard.yml`, `nightly.yml`, `repomix.yml` | Des workflows actifs | Désactivés depuis juin, fichiers inertes |
| `.github/settings.yml` | La configuration du dépôt | Une déclaration que rien n'appliquait |

Les deux premiers ont été traités par suppression ou par acceptation explicite. Celui-ci prend le chemin inverse : le rendre vrai plutôt que le retirer. C'est le seul des trois qui gagne à devenir exécutable — une configuration versionnée et appliquée ne peut plus dériver sans qu'une pull request le montre.