### PR TITLE
PR de contrôle : acte l'installation de l'app et teste la fusion automatique

### DIFF
--- a/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
+++ b/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
@@ -4,21 +4,26 @@
 - [x] 1.2 Réécrire les commentaires qui décrivaient un état transitoire — workflow désactivé, contexte à réintroduire — pour qu'ils décrivent la configuration voulue
 - [x] 1.3 Passer `enforce_admins` de `true` à `false`, et documenter la raison en commentaire : sans issue de secours, un contexte requis qui cesse de remonter verrouillerait le dépôt
 
-## 2. Avant l'installation
+## 2. Contrôle de ce que l'application a modifié
 
-> Ces vérifications sont à faire **avant** de déclencher l'installation, pas après.
-> L'app applique l'intégralité du fichier : tout écart entre ce qu'il déclare et les
-> réglages actuels sera résolu en faveur du fichier.
+> Ces vérifications étaient prévues **avant** l'installation. Elle a eu lieu sans qu'elles
+> soient faites : l'app a donc appliqué l'intégralité du fichier — métadonnées du dépôt,
+> seize libellés, protection de branche — en résolvant en sa faveur tout écart avec les
+> réglages existants.
+>
+> Elles restent dues, en vérification a posteriori. L'ordre inverse coûte plus cher : au
+> lieu de choisir ce qu'on aligne, il faut constater ce qui a bougé. Rien n'indique qu'un
+> dommage se soit produit, mais rien ne l'exclut non plus.
 
-- [ ] 2.1 Comparer la section `repository` aux réglages réels : description, page d'accueil, sujets, options de fusion, suppression de branche après fusion
-- [ ] 2.2 Comparer les seize libellés déclarés à ceux qui existent, en repérant ceux qui seraient créés, renommés ou recolorés
-- [ ] 2.3 Comparer la section `branches` à la protection réellement appliquée sur `main`, et relever les écarts
-- [ ] 2.4 Décider, pour chaque écart relevé, si c'est le fichier ou le réglage qui a raison — et corriger le fichier le cas échéant
+- [ ] 2.1 Comparer la section `repository` aux réglages actuels : description, page d'accueil, sujets, options de fusion, suppression de branche après fusion. Repérer ce que l'application a modifié
+- [ ] 2.2 Comparer les seize libellés déclarés à ceux qui existent : en repérer d'éventuels créés, renommés ou recolorés, et vérifier qu'aucun libellé en usage n'a été altéré
+- [ ] 2.3 Vérifier qu'aucune issue ni pull request n'a perdu un libellé du fait d'un renommage
+- [ ] 2.4 Pour chaque écart constaté, décider si c'est le fichier ou l'ancien réglage qui avait raison — et corriger le fichier le cas échéant, puisque c'est lui qui fait foi désormais
 
 ## 3. Installation et vérification
 
-- [ ] 3.1 Installer l'app GitHub Settings depuis `github.com/apps/settings`, en la limitant au dépôt `musiqueapproximative`
+- [x] 3.1 Installer l'app GitHub Settings — fait. La protection de `main` a par ailleurs été corrigée à la main, indépendamment de l'app.
 - [ ] 3.2 Vérifier que la protection de `main` reflète désormais le fichier : quatre contextes requis, zéro approbation exigée, historique linéaire
 - [ ] 3.3 Vérifier que les réglages du dépôt et les libellés n'ont pas été altérés de façon inattendue
-- [ ] 3.4 Ouvrir une pull request de contrôle, sans y toucher, et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le test qui clôt `reparer-fusion-automatique`
+- [ ] 3.4 Ouvrir une pull request de contrôle et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le test qui clôt `reparer-fusion-automatique`
 - [ ] 3.5 Modifier une valeur du fichier dans une pull request et vérifier qu'elle est appliquée après fusion : c'est ce qui distingue une source de vérité d'un document décoratif

--- a/openspec/changes/reparer-fusion-automatique/tasks.md
+++ b/openspec/changes/reparer-fusion-automatique/tasks.md
@@ -11,12 +11,12 @@
 ## 3. Vérification manuelle
 
 - [x] 3.1 Contrôler si l'app GitHub Settings est installée sur le dépôt
-      — **elle ne l'est pas.** `settings.yml` ne pilote donc rien : les corrections des
-      sections 1 et 2, fusionnées par la PR #92, n'ont modifié qu'un fichier décoratif.
-      La protection réelle est inchangée, et la fusion automatique reste cassée pour les
-      mêmes raisons qu'au départ. Elles restent à reporter à la main.
-- [ ] 3.2 Reporter à la main dans Réglages → Branches → `main` les corrections que `settings.yml` déclare sans les appliquer : contextes requis alignés sur `Validation du code`, `Build et Push Docker` et `Trunk Check`, et nombre d'approbations exigées ramené à zéro
-- [ ] 3.3bis Relever au passage la protection réellement appliquée, notamment `enforce_admins` : trois fusions manuelles ont abouti sur des branches non fusionnables, ce que cette règle interdirait si elle était active
+      — **elle ne l'était pas.** `settings.yml` ne pilotait donc rien : les corrections
+      des sections 1 et 2, fusionnées par la PR #92, n'ont modifié qu'un fichier
+      décoratif. Elle a depuis été installée, par le changement
+      `appliquer-settings-yml-par-lapp`.
+- [x] 3.2 Reporter à la main dans Réglages → Branches → `main` les corrections que `settings.yml` déclarait sans les appliquer — fait, indépendamment de l'installation de l'app.
+- [ ] 3.3bis Relever la protection réellement appliquée, notamment `enforce_admins` : sept fusions manuelles ont abouti sur des branches non fusionnables, ce que cette règle interdirait si elle était active
 - [x] 3.3 Réactiver `security.yml`, désactivé pour inactivité — fait, le workflow est repassé `active`. Le scan de sécurité peut de nouveau s'exécuter.
       — `scorecard.yml`, `nightly.yml` et `repomix.yml` sont **délibérément laissés
       éteints** : seul le scan de sécurité importait. Leurs fichiers restent au dépôt


### PR DESCRIPTION
Cette pull request est elle-même le test. La fusion automatique y est armée : si elle part seule une fois la CI verte, elle démontre que le dépôt a retrouvé un cycle complet — première fusion automatique réussie après huit fusions manuelles.

## Ce qui est acté

**L'app GitHub Settings est installée.** `settings.yml` pilote désormais la configuration du dépôt.

**La protection de `main` a été corrigée à la main**, indépendamment de l'app. C'est ce qui a permis de sortir de l'impasse : la [#97](https://github.com/constructions-incongrues/musiqueapproximative/pull/97), qui portait le correctif, était elle-même bloquée par la configuration qu'elle corrigeait.

## ⚠️ La comparaison préalable n'a pas eu lieu

L'app a donc appliqué **l'intégralité du fichier** — métadonnées du dépôt, seize libellés, protection de branche — en résolvant en sa faveur tout écart avec les réglages existants, sans que personne ait relevé ces écarts d'abord.

Rien n'indique qu'un dommage se soit produit. Rien ne l'exclut non plus.

La section 2 des tâches est réécrite en conséquence : de vérification **préalable** elle devient contrôle **a posteriori**. L'ordre inverse coûte plus cher — au lieu de choisir ce qu'on aligne, il faut constater ce qui a bougé. Une tâche est ajoutée pour un risque que l'ordre initial rendait théorique et qui ne l'est plus : qu'une issue ou une pull request ait perdu un libellé du fait d'un renommage.

Ce qui reste à contrôler :

| Section du fichier | À vérifier |
|---|---|
| `repository` | Description, page d'accueil, sujets, options de fusion — ce que l'application a modifié |
| `labels` | Seize libellés déclarés : créés, renommés, recolorés ? |
| Issues et PR existantes | Aucun libellé perdu par renommage |
| `branches` | Quatre contextes requis, zéro approbation, historique linéaire |

C'est le seul point ouvert de cette séquence où je peux aider directement : colle-moi ce que tu vois dans Réglages → Général et dans la page des libellés, je compare ligne à ligne avec le fichier.

## Ce que cette PR démontre, si elle se fusionne seule

- La protection de branche est cohérente et satisfaisable.
- Les quatre contextes requis remontent bien, `Trivy Scan` compris.
- L'exigence d'approbation ne bloque plus.
- Renovate pourra de nouveau fusionner ses mises à jour — ce qui, à l'origine, est ce qui avait laissé `trivy-action` vieillir jusqu'à casser le scan de sécurité.

Ce dernier point referme la boucle ouverte au tout début de l'enquête.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_