### PR TITLE
Consigne la disparition d'un ruleset — et sert de sonde sur l'état de la protection

### DIFF
--- a/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
+++ b/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
@@ -17,13 +17,37 @@
 
 - [ ] 2.1 Comparer la section `repository` aux réglages actuels : description, page d'accueil, sujets, options de fusion, suppression de branche après fusion. Repérer ce que l'application a modifié
 - [ ] 2.2 Comparer les seize libellés déclarés à ceux qui existent : en repérer d'éventuels créés, renommés ou recolorés, et vérifier qu'aucun libellé en usage n'a été altéré
-- [ ] 2.3 Vérifier qu'aucune issue ni pull request n'a perdu un libellé du fait d'un renommage
+- [x] 2.3 Vérifier qu'aucune issue ni pull request n'a perdu un libellé du fait d'un renommage
+      — sans objet côté issues : le dépôt n'en compte aucune, tous états confondus. Le
+      risque ne subsiste que sur les pull requests closes, où il est cosmétique.
 - [ ] 2.4 Pour chaque écart constaté, décider si c'est le fichier ou l'ancien réglage qui avait raison — et corriger le fichier le cas échéant, puisque c'est lui qui fait foi désormais
 
 ## 3. Installation et vérification
 
+> **Un ruleset a disparu.** Constat rapporté après l'installation, cause non établie.
+>
+> GitHub protège une branche par deux systèmes distincts : les *branch protection rules*
+> classiques, et les *rulesets*, plus récents, dotés d'une API entièrement séparée. À
+> notre connaissance l'app Probot Settings ne pilote que le premier : sa section
+> `branches[].protection` écrit dans l'API classique et ignore les rulesets.
+>
+> Si la protection de ce dépôt était un ruleset, alors `settings.yml` ne la décrivait pas
+> et ne pouvait pas la décrire — ce qui expliquerait que les contextes requis qu'il
+> déclarait ne correspondaient à rien d'observable. La prémisse de ce changement serait
+> alors fausse : le fichier ne peut pas être la source de vérité de la protection, même
+> s'il reste légitime pour les métadonnées et les libellés.
+>
+> À trancher avant toute autre chose. Tant que ce n'est pas établi, `main` est peut-être
+> sans protection.
+
 - [x] 3.1 Installer l'app GitHub Settings — fait. La protection de `main` a par ailleurs été corrigée à la main, indépendamment de l'app.
-- [ ] 3.2 Vérifier que la protection de `main` reflète désormais le fichier : quatre contextes requis, zéro approbation exigée, historique linéaire
+- [ ] 3.2 Établir lequel des deux systèmes gouverne `main` : consulter Réglages → Rules → Rulesets, puis Réglages → Branches. Si un ruleset existait et a disparu, déterminer si l'app en est la cause
+- [ ] 3.2bis Si le dépôt fonctionne aux rulesets, acter que la section `branches` de `settings.yml` est inopérante et décider de son sort — la retirer, ou renoncer aux rulesets au profit de la protection classique
 - [ ] 3.3 Vérifier que les réglages du dépôt et les libellés n'ont pas été altérés de façon inattendue
 - [ ] 3.4 Ouvrir une pull request de contrôle et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le test qui clôt `reparer-fusion-automatique`
+      — première tentative sur la PR #98 : **non concluante**. Les dix checks étaient
+      verts, les quatre contextes requis compris, et la pull request est restée
+      `blocked` plusieurs minutes avant d'être fusionnée sans qu'on puisse dire si
+      l'automatisme a joué. Une exigence non satisfaite subsistait, qui n'était aucun
+      des contextes.
 - [ ] 3.5 Modifier une valeur du fichier dans une pull request et vérifier qu'elle est appliquée après fusion : c'est ce qui distingue une source de vérité d'un document décoratif


### PR DESCRIPTION
Cette pull request est aussi une sonde : son `mergeable_state` à l'ouverture dira si `main` est encore protégée.

## ⚠️ Un ruleset a disparu

Constat rapporté après l'installation de l'app Settings. **La cause n'est pas établie.**

GitHub protège une branche par deux systèmes distincts :

| Système | API | Piloté par `settings.yml` ? |
|---|---|---|
| *Branch protection rules* classiques | Ancienne, `/branches/{branch}/protection` | ✅ oui, section `branches[].protection` |
| *Rulesets* | Séparée, `/rulesets` | ❌ non, à notre connaissance |

L'app Probot Settings n'écrit que dans la première. Elle ne sait ni lire ni écrire un ruleset.

## Ce que ça remettrait en cause

**Si la protection de ce dépôt était un ruleset, la prémisse de ce changement est fausse.**

`settings.yml` ne décrivait alors pas la protection en vigueur, et ne pouvait pas la décrire. Ce qui expliquerait deux anomalies restées sans explication satisfaisante :

- les contextes requis déclarés dans le fichier ne correspondaient à rien d'observable ;
- sept pull requests ont dû être fusionnées à la main, alors que la configuration déclarée aurait dû les laisser passer une fois corrigée.

Le fichier resterait légitime pour les métadonnées et les seize libellés. Sa section `branches`, elle, serait au mieux inerte, au pire concurrente d'un ruleset.

C'est la conclusion inverse de celle qui a motivé les [#97](https://github.com/constructions-incongrues/musiqueapproximative/pull/97) et [#98](https://github.com/constructions-incongrues/musiqueapproximative/pull/98).

## Deux tâches ajoutées

- **3.2** — établir lequel des deux systèmes gouverne `main` : Réglages → Rules → Rulesets, puis Réglages → Branches. Et si un ruleset a disparu, déterminer si l'app en est la cause.
- **3.2bis** — si le dépôt fonctionne aux rulesets, acter que la section `branches` est inopérante et trancher : la retirer du fichier, ou renoncer aux rulesets au profit de la protection classique.

**Tant que ce n'est pas établi, `main` est peut-être sans protection.** C'est le point le plus urgent de la séquence.

## Également consigné

**La première tentative de fusion automatique a échoué** (tâche 3.4, PR #98). Les dix checks étaient verts, les quatre contextes requis satisfaits, et la pull request est restée `blocked` plusieurs minutes avant d'être fusionnée sans qu'on puisse dire si l'automatisme a joué. Une exigence non satisfaite subsistait — et ce n'était aucun des contextes. Le ruleset disparu offre peut-être l'explication.

**Le dépôt ne compte aucune issue**, tous états confondus : la vérification des libellés perdus par renommage est sans objet. Le risque ne subsiste que sur les pull requests closes, où il est cosmétique.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_