### PR TITLE
Aligne la protection de branche sur la référence documentée de l'app

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -102,14 +102,16 @@ labels:
 branches:
   - name: main
     protection:
-      required_pull_request_reviews:
-        # Le dépôt n'a qu'un mainteneur, et GitHub interdit d'approuver sa propre pull
-        # request : exiger une approbation rendait toute fusion automatique impossible,
-        # et contraignait à fusionner à la main en contournant la règle. Le contrôle
-        # avant fusion repose désormais sur les contextes requis ci-dessous.
-        required_approving_review_count: 0
-        dismiss_stale_reviews: true
-        require_code_owner_reviews: false
+      # Aucune revue exigée. Le dépôt n'a qu'un mainteneur, et GitHub interdit
+      # d'approuver sa propre pull request : exiger une approbation rendait toute fusion
+      # automatique impossible, et contraignait à fusionner à la main en contournant la
+      # règle. Le contrôle avant fusion repose sur les contextes requis ci-dessous.
+      #
+      # `null` et non `required_approving_review_count: 0` : la documentation de l'app
+      # donne 1 à 6 comme plage valide, et une valeur hors plage invalide la charge
+      # entière — auquel cas aucun réglage n'est appliqué. Pour ne pas exiger de revue,
+      # la forme attendue est la désactivation complète du bloc.
+      required_pull_request_reviews: null
 
       required_status_checks:
         strict: true
@@ -138,5 +140,8 @@ branches:
       restrictions: null
 
       required_linear_history: true
-      allow_force_pushes: false
-      allow_deletions: false
+
+      # `allow_force_pushes` et `allow_deletions` ont été retirés : ils ne figurent pas
+      # dans la documentation de l'app, et une clé qu'elle ne sait pas transmettre est un
+      # suspect de plus dans une charge qui n'était pas appliquée. À réintroduire, une par
+      # une, si la protection se crée correctement sans elles.

--- a/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
+++ b/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
@@ -58,7 +58,15 @@
       laissait la branche sans protection. La conclusion « il faut désinstaller » est
       retirée.
 - [x] 3.2quinquies Ajouter `restrictions: null` à `.github/settings.yml` — fait.
-- [ ] 3.2sexies Une fois ce correctif dans `main`, vérifier que l'app crée enfin la protection : quatre contextes requis, zéro approbation, historique linéaire. C'est le nouveau test décisif
+- [x] 3.2sexies Vérifier que l'app crée la protection après le correctif `restrictions`
+      — **non, elle n'apparaît toujours pas.** `restrictions` n'était donc pas le seul
+      élément fautif.
+- [x] 3.2septies Aligner strictement la protection sur la référence documentée — fait :
+      `required_pull_request_reviews` passe à `null` plutôt que `required_approving_review_count: 0`,
+      la plage documentée étant 1 à 6 et une valeur hors plage invalidant la charge
+      entière ; `allow_force_pushes` et `allow_deletions`, absents de la documentation,
+      sont retirés. Ne subsistent que les cinq clés que la référence décrit.
+- [ ] 3.2octies Après fusion, vérifier une nouvelle fois si la protection est créée. Si elle ne l'est toujours pas, la cause n'est plus dans le contenu du fichier : chercher du côté des permissions accordées à l'app, ou renoncer et gérer la protection à la main en retirant la section `branches`
 - [ ] 3.3 Vérifier que les réglages du dépôt et les libellés n'ont pas été altérés de façon inattendue
 - [ ] 3.4 Ouvrir une pull request de contrôle et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le test qui clôt `reparer-fusion-automatique`
       — première tentative sur la PR #98 : **non concluante**. Les dix checks étaient


### PR DESCRIPTION
Deuxième tentative. Le correctif `restrictions` de la [#101](https://github.com/constructions-incongrues/musiqueapproximative/pull/101) n'a pas suffi : la protection de `main` n'apparaît toujours pas.

## La règle du tout ou rien

La documentation de l'app pose un principe brutal :

> Each top-level element under branch protection must be filled. If you don't want to use one of them you must set it to `null`. **Otherwise, none of the settings will be applied.**

Une seule valeur invalide, et **rien** n'est appliqué. Pas d'erreur, pas de trace : la protection disparaît simplement. C'est ce qu'on observe depuis le début.

## Le nouveau suspect

```
# The number of approvals required. (1-6)
required_approving_review_count: 1
```

**La plage documentée est 1 à 6.** Nous avions posé `0`, en [#92](https://github.com/constructions-incongrues/musiqueapproximative/pull/92), pour lever l'exigence d'approbation impossible à satisfaire sur un dépôt à un seul mainteneur.

Or ce qu'on veut n'est pas « zéro approbation exigée » mais « pas d'exigence de revue » — et la référence en donne la forme : désactiver le bloc entier.

| Avant | Après |
|---|---|
| `required_pull_request_reviews:` avec `required_approving_review_count: 0` | `required_pull_request_reviews: null` |

## Deux clés retirées

`allow_force_pushes` et `allow_deletions` ne figurent pas dans la documentation de l'app. L'API GitHub les accepte, mais rien ne dit que l'app les transmet — et une clé qu'elle ne sait pas traiter est un suspect de plus dans une charge qui n'était pas appliquée.

Elles sont retirées, à réintroduire une par une si la protection se crée sans elles. C'est une perte temporaire de garde-fou, assumée : mieux vaut une protection réduite qui existe qu'une protection complète qui n'est jamais créée.

## L'état final du bloc

```yaml
protection:
  required_pull_request_reviews: null
  required_status_checks:
    strict: true
    contexts:
      - Validation du code
      - Build et Push Docker
      - Trunk Check
      - Trivy Scan
  enforce_admins: false
  restrictions: null
  required_linear_history: true
```

Cinq clés, exactement celles que la référence décrit. Rien de plus.

## Et si ça ne marche toujours pas

La cause ne sera plus dans le contenu du fichier — il sera alors conforme au modèle de l'éditeur, clé pour clé. Restera à chercher du côté des permissions accordées à l'app lors de son installation, ou à renoncer : gérer la protection à la main et retirer la section `branches` du fichier, pour qu'il cesse de prétendre la piloter.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_