### PR TITLE
docs(openspec): rectifie le diagnostic, main est protégée par un ruleset

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,13 +1,19 @@
 # ⚠️  CE FICHIER N'EST APPLIQUÉ PAR RIEN.
 #
 # Il décrit une intention, pas l'état du dépôt. Les réglages qui font foi sont ceux de
-# l'interface GitHub — Réglages, et Réglages → Branches pour la protection.
+# l'interface GitHub. Pour la protection de `main`, c'est Réglages → Rules → Rulesets —
+# et non Réglages → Branches, qui gouverne l'autre système, celui qui ne s'applique pas
+# ici.
 #
 # Il a été conçu pour l'app GitHub Settings (https://github.com/apps/settings), qui
 # l'appliquerait à chaque push sur la branche par défaut. Elle a été installée le
-# 1er août 2026, puis désinstallée le jour même : loin de créer la protection de branche
-# déclarée ici, elle effaçait celle qui existait, laissant `main` sans protection à deux
-# reprises. Trois alignements successifs sur sa documentation n'y ont rien changé.
+# 1er août 2026, puis désinstallée le jour même, après trois tentatives infructueuses de
+# faire créer par elle la protection de branche déclarée ici.
+#
+# La raison a été comprise après coup : l'app n'écrit que la **protection classique**,
+# tandis que `main` est gouvernée par un **ruleset**. Deux systèmes distincts, deux API
+# distinctes. La section `branches` de ce fichier visait donc, depuis l'origine, un
+# mécanisme qui ne s'applique pas à cette branche. Elle a été retirée.
 #
 # Le fichier est conservé pour mémoire : c'est lui qui garde trace de ce que la
 # configuration du dépôt est censée être. Le lire comme une description de la réalité
@@ -112,18 +118,18 @@ labels:
     color: 0366d6
     description: Mise à jour de dépendances
 
-# La protection de la branche `main` n'est PAS gérée ici.
+# La protection de la branche `main` n'est PAS gérée ici, et ne peut pas l'être.
 #
-# Elle l'a été un temps, et c'était une erreur. L'app Settings appliquait ce fichier à
-# chaque push sur la branche par défaut, et la section `branches` ne produisait aucune
-# protection — elle effaçait celle qui existait. Trois tentatives d'alignement sur la
-# documentation de l'app ont échoué : ajout de `restrictions`, passage de
-# `required_pull_request_reviews` à `null`, retrait des clés non documentées. `main` s'est
-# retrouvée sans protection à deux reprises.
+# Elle est assurée par un **ruleset** — Réglages → Rules → Rulesets. Les rulesets sont un
+# système à part, avec leur propre API. L'app Settings ne sait écrire que la protection
+# *classique*, celle de Réglages → Branches. Quoi qu'on déclare dans une section
+# `branches` ici, cela ne peut donc ni créer, ni modifier, ni supprimer le ruleset qui
+# gouverne réellement `main`.
 #
-# La protection est désormais gérée à la main, dans Réglages → Branches. Ce fichier ne la
-# décrit plus, pour ne plus prétendre piloter ce qu'il ne pilote pas — et surtout pour ne
-# plus la détruire.
+# La section a bien existé, et trois tentatives d'alignement sur la documentation de l'app
+# ont échoué à produire quoi que ce soit : ajout de `restrictions`, passage de
+# `required_pull_request_reviews` à `null`, retrait des clés non documentées. On cherchait
+# la panne dans le fichier alors qu'elle était dans le choix du système.
 #
-# Ne pas réintroduire de section `branches` sans avoir d'abord vérifié, sur un dépôt
-# d'essai, que l'app crée bien la protection au lieu de la supprimer.
+# Ne pas réintroduire de section `branches` : elle décrirait un mécanisme inactif sur ce
+# dépôt, et un lecteur pressé la prendrait pour la protection en vigueur.

--- a/openspec/changes/appliquer-settings-yml-par-lapp/proposal.md
+++ b/openspec/changes/appliquer-settings-yml-par-lapp/proposal.md
@@ -1,11 +1,19 @@
 ## Why
 
 > **Issue de ce changement : renoncement.** L'app n'a jamais créé la protection de
-> branche, malgré trois alignements successifs sur sa documentation. Elle effaçait en
-> revanche celle qui existait, à chaque push sur la branche par défaut — `main` s'est
-> retrouvée sans protection à deux reprises. La section `branches` a été retirée du
-> fichier ; la protection est gérée à la main. Les sections `repository` et `labels`
-> restent pilotées par l'app, et leur sort n'est pas tranché.
+> branche, malgré trois alignements successifs sur sa documentation. La section `branches`
+> a été retirée du fichier, et l'app désinstallée.
+>
+> **La raison n'a été comprise qu'après.** GitHub offre deux systèmes de protection : les
+> règles *classiques*, seules pilotables par l'app, et les *rulesets*, qui ont leur propre
+> API et lui échappent entièrement. `main` est gouvernée par un ruleset. La section
+> `branches` visait donc, depuis l'origine, un mécanisme sans effet sur cette branche.
+>
+> Cette confusion a coûté toute l'enquête. Elle a fait conclure tour à tour que l'app était
+> inerte, qu'elle détruisait la protection, puis que `main` n'était plus protégée du tout —
+> trois conclusions fausses, tirées d'observations faites sur le mauvais écran. Ce qu'on
+> voyait apparaître et disparaître sous Réglages → Branches était la règle classique que
+> l'app n'arrivait pas à créer ; le ruleset, lui, n'a jamais bougé.
 >
 > Ce qui suit décrit l'intention initiale, conservée telle quelle pour mémoire.
 

--- a/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
+++ b/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
@@ -126,6 +126,12 @@
       revues, historique linéaire. C'est la dernière inconnue : une exigence qui ne peut
       jamais être satisfaite expliquerait à elle seule que la fusion automatique n'ait
       jamais abouti en une quinzaine de pull requests
+      — le test de `reparer-fusion-automatique` 3.6 réduit le champ à deux candidats :
+      **une approbation exigée** (insatisfiable à un seul mainteneur, qui est l'auteur), ou
+      **un contexte requis fantôme** du type `Build Docker`. Deux réglages à lire dans
+      l'écran du ruleset : « Require a pull request before merging » → *Required approvals*,
+      qu'il faut mettre à **0**, et « Require status checks to pass » → la liste, qui ne
+      doit contenir que `Validation du code`, `Build et Push Docker` et `Trunk Check`.
 - [x] 3.5 Décider du sort des sections `repository` et `labels`
       — **tranché par les faits : l'app est désinstallée.** Plus rien n'applique le
       fichier, quelle que soit sa section. `settings.yml` redevient ce qu'il était au

--- a/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
+++ b/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
@@ -27,25 +27,47 @@
 
 ## 3. Installation et vérification
 
-> **La prémisse de ce changement est fausse.** Constat établi après vérification des
-> réglages du dépôt : il n'existait plus **ni ruleset, ni règle de protection classique**
-> sur `main`. La branche était sans aucune protection.
+> **La prémisse de ce changement est fausse**, mais pas pour la raison qu'on a d'abord
+> retenue. Deux systèmes de protection coexistent sur GitHub, et toute cette section les a
+> confondus :
 >
-> `settings.yml` déclare pourtant une section `branches` complète, l'app est installée, et
-> plusieurs push sur la branche par défaut ont eu lieu depuis. Aucune règle n'a été créée.
-> **L'app n'applique donc pas le fichier.** Deux lectures, non départagées : elle échoue
-> silencieusement — permissions, ou section refusée par l'API — ou bien elle a supprimé la
-> protection existante sans la remplacer.
+> - les **règles classiques**, sous Réglages → Branches, seules pilotables par l'app
+>   Settings — c'est ce que décrivait la section `branches` du fichier ;
+> - les **rulesets**, sous Réglages → Rules → Rulesets, un système distinct avec sa propre
+>   API, que l'app ne sait **ni créer, ni modifier, ni supprimer**.
 >
-> Dans les deux cas, faire de ce fichier la source de vérité de la protection ne marche
-> pas. Il reste légitime pour les métadonnées et les libellés.
+> `main` est gouvernée par un **ruleset**. Il porte le nom `main`, il est actif, et sa
+> liste de contournement comporte « Repository admin — Always allow ». L'API le confirme :
+> `main` remonte `protected: true`.
 >
-> Une protection a été restaurée à la main. La prochaine fusion sur `main` dira si l'app
-> la supprime à nouveau : c'est le test qui désigne le coupable.
+> Ce qu'il faut en tirer :
+>
+> - l'app n'a **jamais pu** effacer la protection de `main`, contrairement à ce que
+>   trois entrées ci-dessous affirment. Ce qui disparaissait sous Réglages → Branches était
+>   la règle classique, que l'app n'arrivait pas à créer ; le ruleset, lui, n'a jamais été
+>   dans son périmètre ;
+> - la protection n'a donc probablement jamais cessé de s'appliquer. Les réponses
+>   successives « le ruleset a disparu », puis « plus rien », portaient sur des écrans qui
+>   ne montraient pas le bon système ;
+> - **c'est l'explication de la fusion automatique qui ne se déclenche jamais.** Le
+>   contournement administrateur autorise le mainteneur à fusionner à la main, quoi que
+>   dise le ruleset — ce qu'il a fait sept fois. La fusion automatique, elle, n'emprunte
+>   pas ce contournement : elle attend que la pull request soit réellement fusionnable.
+>   Une exigence du ruleset jamais satisfaite laisse donc les deux états observés
+>   simultanément — `blocked` pour l'automatisme, fusionnable à la main.
+>
+> Reste à établir ce que le ruleset exige : c'est l'objet de 3.4bis.
+>
+> Ce qui subsiste de valide : faire de `settings.yml` la source de vérité de la protection
+> ne marche pas, puisque le fichier ne peut atteindre que le système classique — celui qui
+> ne gouverne pas cette branche. Il reste légitime pour les métadonnées et les libellés.
 
 - [x] 3.1 Installer l'app GitHub Settings — fait. La protection de `main` a par ailleurs été corrigée à la main, indépendamment de l'app.
 - [x] 3.2 Établir lequel des deux systèmes gouverne `main`
-      — **aucun des deux.** Ni ruleset, ni règle classique. La branche était ouverte.
+      — **le ruleset.** Un ruleset nommé `main`, à l'état actif, contournable par les
+      administrateurs du dépôt. L'app Settings n'a aucune prise dessus : elle n'écrit que
+      la protection classique. La réponse « aucun des deux », portée ici pendant toute
+      l'enquête, était fausse ; elle vient d'avoir été relevée sur le mauvais écran.
 - [x] 3.2bis Décider du sort de la section `branches` de `settings.yml`
       — la question ne se pose plus dans les termes prévus : ce n'est pas que le fichier
       décrive le mauvais système, c'est que l'app ne l'applique pas du tout. La décision
@@ -60,6 +82,10 @@
       L'app envoyait donc une charge incomplète à l'API, qui n'en retenait rien et
       laissait la branche sans protection. La conclusion « il faut désinstaller » est
       retirée.
+      — **Rectifié depuis** : « la protection a disparu » désignait la règle classique,
+      seule chose que l'app manipule et qu'elle n'a jamais réussi à créer. Le ruleset qui
+      gouverne réellement `main` était hors de sa portée et n'a pas bougé. L'app n'a rien
+      détruit ; elle n'a rien produit non plus.
 - [x] 3.2quinquies Ajouter `restrictions: null` à `.github/settings.yml` — fait.
 - [x] 3.2sexies Vérifier que l'app crée la protection après le correctif `restrictions`
       — **non, elle n'apparaît toujours pas.** `restrictions` n'était donc pas le seul
@@ -74,10 +100,15 @@
       l'app — ajout de `restrictions`, `required_pull_request_reviews` à `null`, retrait
       des clés non documentées — la protection n'est toujours pas créée. Le coût de
       l'enquête dépasse désormais le bénéfice attendu.
-- [x] 3.2nonies Retirer la section `branches` de `.github/settings.yml` — fait. Tant
-      qu'elle y figurait, chaque fusion sur `main` effaçait la protection. Un commentaire
-      la remplace, qui dit pourquoi et met en garde contre sa réintroduction.
-- [ ] 3.2decies Restaurer la protection de `main` à la main, une dernière fois. Elle ne sera plus effacée, la section fautive ayant disparu du fichier
+- [x] 3.2nonies Retirer la section `branches` de `.github/settings.yml` — fait. Un
+      commentaire la remplace, qui dit pourquoi et met en garde contre sa réintroduction.
+      — **Rectifié** : la section n'effaçait pas la protection, elle échouait à en créer
+      une. Son retrait reste le bon geste, pour une raison plus simple que celle
+      invoquée : elle décrit un système — la protection classique — qui ne gouverne pas
+      cette branche, et laisser un fichier prétendre le contraire égare le lecteur.
+- [x] 3.2decies Restaurer la protection de `main`
+      — **sans objet : elle n'avait pas disparu.** Le ruleset `main` est actif, et l'API
+      rapporte `protected: true` sur la branche. Il n'y avait rien à restaurer.
 - [x] 3.3 Vérifier que les réglages du dépôt et les libellés n'ont pas été altérés
       — jamais fait, et désormais sans urgence : l'app est désinstallée, plus rien
       n'applique le fichier. Un écart éventuel resterait figé plutôt que réappliqué.
@@ -86,8 +117,15 @@
       — première tentative sur la PR #98 : **non concluante**. Les dix checks étaient
       verts, les quatre contextes requis compris, et la pull request est restée
       `blocked` plusieurs minutes avant d'être fusionnée sans qu'on puisse dire si
-      l'automatisme a joué. Reste inexpliqué : sans aucune protection, GitHub aurait dû
-      rapporter `clean`. Une règle au niveau de l'organisation reste à écarter.
+      l'automatisme a joué.
+      — **L'anomalie de cette tentative est levée.** « Sans aucune protection, GitHub
+      aurait dû rapporter `clean` » : la protection existait bel et bien, sous forme de
+      ruleset. `blocked` était la réponse correcte. Il n'y a pas de règle d'organisation à
+      écarter.
+- [ ] 3.4bis Relever ce que le ruleset `main` exige — contextes de vérification requis,
+      revues, historique linéaire. C'est la dernière inconnue : une exigence qui ne peut
+      jamais être satisfaite expliquerait à elle seule que la fusion automatique n'ait
+      jamais abouti en une quinzaine de pull requests
 - [x] 3.5 Décider du sort des sections `repository` et `labels`
       — **tranché par les faits : l'app est désinstallée.** Plus rien n'applique le
       fichier, quelle que soit sa section. `settings.yml` redevient ce qu'il était au

--- a/openspec/changes/reparer-fusion-automatique/proposal.md
+++ b/openspec/changes/reparer-fusion-automatique/proposal.md
@@ -106,8 +106,18 @@ alors que trois fusions manuelles ont abouti sur des branches non fusionnables.
 
 Vérification faite : **l'app n'est pas installée**. Éditer ce fichier n'a donc rien changé
 à la protection réelle. Les corrections des sections 1 et 2 sont restées lettre morte, et
-la fusion automatique demeure cassée pour les raisons décrites plus haut. Elles doivent
-être reportées à la main dans Réglages → Branches, ce que trace la tâche 3.2.
+la fusion automatique demeure cassée pour les raisons décrites plus haut.
+
+**Rectification, établie après coup.** Les reporter dans Réglages → Branches, comme le
+prescrivait la tâche 3.2, ne pouvait pas marcher non plus : `main` est protégée par un
+**ruleset**, sous Réglages → Rules → Rulesets. Deux systèmes coexistent chez GitHub, et
+toute cette enquête a raisonné sur le mauvais. L'app Settings n'écrit que le système
+classique, ce qui explique du même coup pourquoi elle ne produisait jamais rien de
+visible.
+
+L'analyse des causes ci-dessus reste valable sur le fond — un contexte requis qui ne
+remonte jamais bloque effectivement la branche — mais elle visait un objet inerte. Les
+tâches 3.3bis, 3.3ter et 3.3quater portent le diagnostic corrigé.
 
 Ce constat désigne un problème plus large que ce changement : `settings.yml` décrit une
 configuration qui n'est pas celle du dépôt. C'est le troisième artefact de ce genre

--- a/openspec/changes/reparer-fusion-automatique/tasks.md
+++ b/openspec/changes/reparer-fusion-automatique/tasks.md
@@ -16,7 +16,20 @@
       décoratif. Elle a depuis été installée, par le changement
       `appliquer-settings-yml-par-lapp`.
 - [x] 3.2 Reporter à la main dans Réglages → Branches → `main` les corrections que `settings.yml` déclarait sans les appliquer — fait, indépendamment de l'installation de l'app.
-- [ ] 3.3bis Relever la protection réellement appliquée, notamment `enforce_admins` : sept fusions manuelles ont abouti sur des branches non fusionnables, ce que cette règle interdirait si elle était active
+      — **mauvais écran.** Réglages → Branches gouverne les règles classiques ; `main` est
+      protégée par un ruleset, sous Réglages → Rules → Rulesets. Les corrections portées
+      là n'ont donc jamais rencontré la protection qui s'applique réellement, ce qui
+      explique qu'elles aient paru s'évaporer d'une fusion à l'autre.
+- [x] 3.3bis Relever la protection réellement appliquée, notamment `enforce_admins` : sept fusions manuelles ont abouti sur des branches non fusionnables, ce que cette règle interdirait si elle était active
+      — **relevé, et c'est le nœud de toute l'affaire.** `main` n'est pas gouvernée par une
+      règle classique mais par un **ruleset** — un second système de protection, avec sa
+      propre interface et sa propre API, sur lequel `settings.yml` et l'app Settings n'ont
+      aucune prise. Ce ruleset est actif, et sa liste de contournement comporte
+      « Repository admin — Always allow », l'équivalent d'`enforce_admins: false`.
+      Les sept fusions manuelles s'expliquent : elles empruntaient ce contournement.
+      La fusion automatique, elle, ne l'emprunte pas — elle attend une pull request
+      réellement fusionnable. D'où les deux états observés ensemble tout au long de
+      l'enquête : `blocked` pour l'automatisme, et fusionnable à la main.
 - [x] 3.3 Réactiver `security.yml`, désactivé pour inactivité — fait, le workflow est repassé `active`. Le scan de sécurité peut de nouveau s'exécuter.
       — `scorecard.yml`, `nightly.yml` et `repomix.yml` sont **délibérément laissés
       éteints** : seul le scan de sécurité importait. Leurs fichiers restent au dépôt

--- a/openspec/changes/reparer-fusion-automatique/tasks.md
+++ b/openspec/changes/reparer-fusion-automatique/tasks.md
@@ -64,10 +64,27 @@
       `settings.yml`, la banque de mémoire et les badges morts : un quatrième document qui
       décrit sans contraindre. Les mises à jour de dépendances viennent toutes de
       Dependabot, qui n'a pas de fusion automatique configurée.
-- [ ] 3.6 Ouvrir une pull request de contrôle, sans y toucher, et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le seul test qui valide l'objet de ce changement
-      — la PR #105 sert de contrôle. Le test ne peut se faire qu'une fois le brouillon
-      levé, et la fusion automatique activée explicitement : ce sont les deux préalables
-      que l'on ignorait.
+- [x] 3.6 Ouvrir une pull request de contrôle, sans y toucher, et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le seul test qui valide l'objet de ce changement
+      — **fait sur la PR #105, et le test est concluant : la fusion ne se déclenche pas.**
+      Conditions du relevé, toutes réunies : brouillon levé, fusion automatique armée en
+      `squash`, **neuf checks terminés et tous en succès** — `Validation du code`,
+      `Build et Push Docker`, `Trunk Check`, `Trunk Check Runner`, `CodeQL`,
+      `Analyze (actions)`, `Analyze (javascript-typescript)`, `GitGuardian Security
+      Checks`, plus `Créer alias de version` en `skipped`. Aucun `Trivy Scan`.
+      `mergeable_state` reste `blocked`.
+      — Il ne reste donc qu'une exigence non satisfaite, et **zéro revue** figure sur la
+      pull request. L'explication qui tient sans rien supposer d'autre : le ruleset exige
+      au moins une approbation. Sur un dépôt à un seul mainteneur, qui est aussi l'auteur
+      de la pull request, GitHub interdit l'auto-approbation — l'exigence est donc
+      **structurellement insatisfiable**, et le contournement administrateur est la seule
+      issue. C'est exactement le comportement observé depuis le début.
+      — Le diagnostic initial de ce changement avait vu juste sur ce point : il visait
+      `required_approving_review_count: 1`, et le faisait passer à `0`. Mais il l'a corrigé
+      dans `settings.yml`, qui ne pilote rien, au lieu du ruleset, qui gouverne. Le
+      correctif était bon ; il a été appliqué au mauvais endroit.
+      — Reste une seconde hypothèse, non écartée faute d'accès à l'API des rulesets : un
+      contexte requis fantôme, `Build Docker` par exemple, qui ne remonterait jamais. Elle
+      se départage d'un coup d'œil à 3.4bis.
 - [x] 3.7 Vérifier que le badge « Security Scan » du README repasse au vert, son résultat étant figé au 11 avril 2026
       — le run #202 de « Security Checks », déclenché à la main sur `main`, a abouti.
       Le badge affiche la conclusion du dernier run sur la branche par défaut.

--- a/openspec/changes/reparer-fusion-automatique/tasks.md
+++ b/openspec/changes/reparer-fusion-automatique/tasks.md
@@ -45,7 +45,29 @@
       laisserait la branche indéfiniment non fusionnable, reproduisant le blocage que
       `Build Docker` a provoqué six mois durant. Les contextes à déclarer sont
       `Validation du code`, `Build et Push Docker` et `Trunk Check`.
+- [x] 3.3ter Établir ce qui, dans ce dépôt, est censé **activer** la fusion automatique
+      — **rien.** C'est le second volet de l'explication, et le plus embarrassant : la
+      fusion automatique de GitHub n'a rien d'automatique. Elle s'active pull request par
+      pull request, à la main ou par un appel d'API. Aucun workflow du dépôt ne le fait —
+      les dix fichiers de `.github/workflows/` ne mentionnent jamais l'auto-merge — et
+      aucune app ne s'en charge.
+      — Conséquence pour les pull requests de cette enquête : **elle n'y a jamais été
+      activée**, et il n'y avait donc rien à déclencher. Un obstacle mécanique s'y ajoute :
+      elles sont ouvertes en brouillon, et GitHub refuse d'activer la fusion automatique
+      sur un brouillon. Vérifié sur la PR #105, où l'API répond « Pull request is a draft ».
+      — Cela ne vaut pas pour les #89, #90 et #91, où l'énoncé de ce changement rapporte
+      qu'elle avait bien été armée. Ce sont ces trois-là que le ruleset explique, par le
+      contournement administrateur relevé en 3.3bis.
+- [x] 3.3quater Vérifier ce que fait Renovate, dont la configuration déclare `automerge: true`
+      — **elle ne fait rien : Renovate n'a jamais ouvert une seule pull request sur ce
+      dépôt**, aucun état confondu. L'app n'est pas installée. `renovate.json` rejoint donc
+      `settings.yml`, la banque de mémoire et les badges morts : un quatrième document qui
+      décrit sans contraindre. Les mises à jour de dépendances viennent toutes de
+      Dependabot, qui n'a pas de fusion automatique configurée.
 - [ ] 3.6 Ouvrir une pull request de contrôle, sans y toucher, et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le seul test qui valide l'objet de ce changement
+      — la PR #105 sert de contrôle. Le test ne peut se faire qu'une fois le brouillon
+      levé, et la fusion automatique activée explicitement : ce sont les deux préalables
+      que l'on ignorait.
 - [x] 3.7 Vérifier que le badge « Security Scan » du README repasse au vert, son résultat étant figé au 11 avril 2026
       — le run #202 de « Security Checks », déclenché à la main sur `main`, a abouti.
       Le badge affiche la conclusion du dernier run sur la branche par défaut.

--- a/openspec/changes/retirer-scan-trivy/proposal.md
+++ b/openspec/changes/retirer-scan-trivy/proposal.md
@@ -48,7 +48,8 @@ nuance que l'archivage doit conserver.
   `repomix.yml` — dont les fichiers subsistent. Leur sort reste à décider, et ce
   changement ne le préjuge pas.
 - CodeQL, GitGuardian, Dependabot et Renovate, tous conservés.
-- La restauration de la protection de `main`, qui incombe au mainteneur.
+- Le contenu du ruleset qui protège `main`, dont la mise à jour incombe au mainteneur —
+  il faut seulement s'assurer que `Trivy Scan` n'y figure pas comme contexte requis.
 
 ## Capacités
 

--- a/openspec/changes/retirer-scan-trivy/tasks.md
+++ b/openspec/changes/retirer-scan-trivy/tasks.md
@@ -9,7 +9,7 @@
 - [x] 2.1 Sur la pull request de ce changement, vérifier qu'aucun check `Trivy Scan` n'apparaît plus
       — vérifié sur la PR #103 : le check a disparu de la liste, alors qu'il figurait sur
       toutes les pull requests depuis la #96.
-- [ ] 2.2 **Au moment de restaurer la protection de `main`, ne pas y déclarer `Trivy Scan` comme contexte requis.** Un contexte qui ne remonte jamais laisse la branche indéfiniment non fusionnable, sans message d'erreur. Les trois contextes qui subsistent sont `Validation du code`, `Build et Push Docker` et `Trunk Check`
+- [ ] 2.2 **Vérifier que `Trivy Scan` ne figure pas parmi les contextes requis du ruleset `main`**, et l'en retirer le cas échéant. Un contexte qui ne remonte jamais laisse la branche indéfiniment non fusionnable, sans message d'erreur — c'est le premier suspect pour expliquer que la fusion automatique n'ait jamais abouti. Les trois contextes qui subsistent sont `Validation du code`, `Build et Push Docker` et `Trunk Check`. À relever sous Réglages → Rules → Rulesets → `main`, et non sous Réglages → Branches
 - [x] 2.3 Vérifier que le README et la page d'accueil de la documentation ne comportent plus de badge mort
       — vérifié sur `main` : zéro occurrence de `security.yml` dans `README.adoc` et dans
       `docs/modules/ROOT/pages/index.adoc`, et le fichier de workflow n'existe plus.


### PR DESCRIPTION
## Contexte

L'enquête sur la fusion automatique — trois changements, une quinzaine de pull requests — reposait sur une **confusion entre les deux systèmes de protection de GitHub** :

| | Règles classiques | Rulesets |
|---|---|---|
| Où | Réglages → Branches | Réglages → Rules → Rulesets |
| API | `/branches/:b/protection` | `/rulesets` |
| Pilotable par l'app Settings | oui | **non** |

`main` est gouvernée par un **ruleset**. L'API le confirme : la branche remonte `protected: true`.

## Ce que cela corrige

Trois conclusions successives étaient fausses, toutes tirées d'observations faites sous Réglages → Branches :

1. « l'app Settings est inerte » ;
2. « l'app efface la protection à chaque fusion » ;
3. « `main` n'est plus protégée du tout ».

Ce qui apparaissait et disparaissait là était la règle *classique*, que l'app n'a jamais réussi à créer. Le ruleset, hors de sa portée, n'a jamais bougé.

## Ce que cela explique

Le ruleset comporte **« Repository admin — Always allow »** dans sa liste de contournement. C'est ce qui concilie enfin les deux faits qui résistaient depuis le début :

- **sept fusions manuelles abouties** sur des branches rapportées non fusionnables — elles empruntaient le contournement administrateur ;
- **une fusion automatique qui ne s'est jamais déclenchée** — elle ne l'emprunte pas, et attend une pull request réellement fusionnable.

Une exigence du ruleset jamais satisfaite produit donc exactement les deux états observés ensemble : `blocked` pour l'automatisme, fusionnable à la main.

## Modifications

- `openspec/changes/appliquer-settings-yml-par-lapp/` — préambule de la section 3 réécrit, tâches 3.2, 3.2quater, 3.2nonies et 3.4 rectifiées, 3.2decies close comme sans objet, 3.4bis ajoutée (relever ce que le ruleset exige).
- `openspec/changes/reparer-fusion-automatique/tasks.md` — 3.3bis close : c'est elle qui posait la question, la voici résolue. 3.2 annotée « mauvais écran ».
- `openspec/changes/retirer-scan-trivy/` — 2.2 redirigée vers le ruleset.
- `.github/settings.yml` — l'en-tête pointait le lecteur vers Réglages → Branches, c'est-à-dire vers le système qui ne s'applique pas ici. Rectifié, ainsi que le commentaire qui accusait l'app d'avoir détruit la protection.

Aucun fichier de `src/` n'est touché. Contrat public inchangé.

## Reste ouvert

Ce que le ruleset **exige** — contextes requis, revues — n'est pas encore relevé. Si `Trivy Scan` ou `Build Docker` y figurent encore, la fusion automatique restera bloquée indéfiniment : le workflow qui produisait le premier a été supprimé, et le second n'a jamais existé sous ce nom.

Cette pull request sert de test : la fusion automatique y est activée, sans intervention manuelle.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_