### PR TITLE
docs(openspec): la PR #105 a fusionné, le blocage a cédé

### DIFF
--- a/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
+++ b/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
@@ -132,6 +132,15 @@
       l'écran du ruleset : « Require a pull request before merging » → *Required approvals*,
       qu'il faut mettre à **0**, et « Require status checks to pass » → la liste, qui ne
       doit contenir que `Validation du code`, `Build et Push Docker` et `Trunk Check`.
+      — **Le ruleset a été corrigé dans la foulée**, et la PR #105 a fusionné. Le contenu
+      exact d'avant et d'après n'a pas été relevé — l'API des rulesets n'est pas accessible
+      d'ici — mais le blocage a cédé, ce qui suffit à valider le raisonnement. Reste à
+      consigner la configuration retenue, pour qu'elle cesse d'être une connaissance
+      orale : c'est l'objet de 3.4ter.
+- [ ] 3.4ter Consigner dans le dépôt la configuration du ruleset `main` — contextes requis,
+      approbations exigées, liste de contournement. Sans quoi la prochaine dérive
+      silencieuse mettra encore six mois à se voir. Un fichier de documentation, pas un
+      fichier appliqué : `settings.yml` a montré ce que coûte la confusion entre les deux
 - [x] 3.5 Décider du sort des sections `repository` et `labels`
       — **tranché par les faits : l'app est désinstallée.** Plus rien n'applique le
       fichier, quelle que soit sa section. `settings.yml` redevient ce qu'il était au

--- a/openspec/changes/reparer-fusion-automatique/tasks.md
+++ b/openspec/changes/reparer-fusion-automatique/tasks.md
@@ -65,8 +65,10 @@
       décrit sans contraindre. Les mises à jour de dépendances viennent toutes de
       Dependabot, qui n'a pas de fusion automatique configurée.
 - [x] 3.6 Ouvrir une pull request de contrôle, sans y toucher, et vérifier que la fusion automatique se déclenche seule une fois la CI verte — c'est le seul test qui valide l'objet de ce changement
-      — **fait sur la PR #105, et le test est concluant : la fusion ne se déclenche pas.**
-      Conditions du relevé, toutes réunies : brouillon levé, fusion automatique armée en
+      — **fait sur la PR #105. Le test a deux temps, et le second renverse le premier.**
+
+      **Premier temps — bloqué.** Conditions du relevé, toutes réunies : brouillon levé,
+      fusion automatique armée en
       `squash`, **neuf checks terminés et tous en succès** — `Validation du code`,
       `Build et Push Docker`, `Trunk Check`, `Trunk Check Runner`, `CodeQL`,
       `Analyze (actions)`, `Analyze (javascript-typescript)`, `GitGuardian Security
@@ -82,9 +84,39 @@
       `required_approving_review_count: 1`, et le faisait passer à `0`. Mais il l'a corrigé
       dans `settings.yml`, qui ne pilote rien, au lieu du ruleset, qui gouverne. Le
       correctif était bon ; il a été appliqué au mauvais endroit.
-      — Reste une seconde hypothèse, non écartée faute d'accès à l'API des rulesets : un
-      contexte requis fantôme, `Build Docker` par exemple, qui ne remonterait jamais. Elle
-      se départage d'un coup d'œil à 3.4bis.
+      — Restait une seconde hypothèse, non écartée faute d'accès à l'API des rulesets : un
+      contexte requis fantôme, `Build Docker` par exemple, qui ne remonterait jamais.
+
+      **Second temps — la PR #105 a fusionné.** Une fois le blocage signalé et le ruleset
+      corrigé, elle est partie. La chronologie du 1er août :
+
+      | Heure (UTC) | Événement |
+      |---|---|
+      | 22:28 | fusion automatique armée en `squash`, `mergeable_state` : `blocked` |
+      | 22:29:30 | poussée du commit `8a1ac19`, qui remplace la tête |
+      | 22:30:13 | `ci.yml` abouti ; les autres workflows suivent vers 22:31 |
+      | 22:32:48 | **fusionnée** |
+
+      Deux lectures possibles, et il faut le dire plutôt que trancher au forceps :
+
+      - **la fusion automatique s'est déclenchée.** C'est la lecture que la chronologie
+        soutient. La tête précédente, `8075c60`, était verte dès 22:24:52 et n'a pas été
+        fusionnée : elle est restée `blocked` près de quatre minutes. Rien n'a bougé tant
+        que la fusion automatique n'était pas armée. Une fois armée, et une fois la CI de
+        la nouvelle tête verte, la fusion suit d'environ une minute et demie — c'est le
+        délai de propagation habituel de l'automatisme ;
+      - **une fusion manuelle par contournement administrateur**, tombée par coïncidence
+        dans cette fenêtre. L'API ne permet pas de les distinguer : dans les deux cas
+        `merged_by` porte le nom du mainteneur, puisque la fusion automatique s'exécute
+        au nom de qui l'a armée.
+
+      Ce que le second temps établit sans ambiguïté, en revanche : **`main` était bien
+      protégée**, et l'exigence qui bloquait a cédé dès qu'on a regardé le bon écran. La
+      conclusion du premier temps — « la fusion ne se déclenche pas » — n'était vraie que
+      du ruleset non corrigé.
+- [ ] 3.6bis Confirmer d'une pull request suivante que la fusion automatique se déclenche
+      bien seule, en l'armant et en n'y touchant plus. C'est le seul geste qui départage
+      les deux lectures ci-dessus, et il ne coûte rien : la prochaine pull request suffit
 - [x] 3.7 Vérifier que le badge « Security Scan » du README repasse au vert, son résultat étant figé au 11 avril 2026
       — le run #202 de « Security Checks », déclenché à la main sur `main`, a abouti.
       Le badge affiche la conclusion du dernier run sur la branche par défaut.


### PR DESCRIPTION
## Ce que corrige cette pull request

La #105 consignait, en tâche 3.6, que « le test est concluant : la fusion ne se déclenche pas ». **Elle a fusionné quelques minutes plus tard.** Cette conclusion, telle qu'elle est écrite dans `main`, est donc fausse — ou plutôt, elle n'est vraie que du ruleset non corrigé.

## Chronologie du 1er août (UTC)

| Heure | Événement |
|---|---|
| 22:24:52 | CI verte sur la tête `8075c60` — la PR reste `blocked`, non fusionnée |
| 22:28 | fusion automatique armée en `squash` ; `mergeable_state` toujours `blocked` |
| 22:29:30 | poussée de `8a1ac19`, qui remplace la tête |
| 22:30:13 | `ci.yml` abouti ; les autres workflows suivent vers 22:31 |
| 22:32:48 | **fusionnée** |

## Deux lectures, non départagées

- **La fusion automatique s'est déclenchée** — la lecture que la chronologie soutient. La tête précédente était verte depuis quatre minutes et n'a pas bougé ; rien ne s'est produit tant que l'automatisme n'était pas armé, puis la fusion a suivi la CI verte d'une minute et demie, ce qui est le délai de propagation habituel.
- **Une fusion manuelle par contournement administrateur**, tombée dans la même fenêtre. L'API ne permet pas de trancher : `merged_by` porte le nom du mainteneur dans les deux cas, la fusion automatique s'exécutant au nom de qui l'a armée.

Plutôt que de trancher au forceps, les deux lectures sont consignées, et une tâche `3.6bis` prévoit de les départager sur la prochaine pull request — il suffit d'armer la fusion automatique et de n'y plus toucher.

## Ce qui est établi sans ambiguïté

`main` **était** protégée, et l'exigence qui bloquait a cédé dès qu'on a regardé le bon écran. C'était l'objet de toute l'enquête.

## Modifications

- `openspec/changes/reparer-fusion-automatique/tasks.md` — 3.6 réécrite en deux temps, le second renversant le premier ; ajout de 3.6bis.
- `openspec/changes/appliquer-settings-yml-par-lapp/tasks.md` — 3.4bis close ; ajout de 3.4ter : consigner la configuration du ruleset, aujourd'hui connaissance purement orale, faute de quoi la prochaine dérive silencieuse mettra encore six mois à se voir.

Documentation seule. Aucun fichier de `src/` n'est touché.

## Note

Ouverte en brouillon, comme toutes les pull requests de cet agent. La fusion automatique ne peut pas y être armée tant qu'elle l'est — c'est précisément l'obstacle que la tâche 3.3ter consigne. Pour que cette pull request serve aussi de test à 3.6bis, il faut lever le brouillon puis armer la fusion automatique, et ne plus y toucher.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_