### PR TITLE
docs(openspec): propose la réparation des imports de désastres et la généralisation des triggers

### DIFF
--- a/openspec/changes/generaliser-trigger-desastres/.openspec.yaml
+++ b/openspec/changes/generaliser-trigger-desastres/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: musique-approximative
+created: 2026-08-01
+goal: Doter chaque règle de désastre d'un paramètre trigger, pour rendre la
+  capacité vérifiable de l'extérieur

--- a/openspec/changes/generaliser-trigger-desastres/proposal.md
+++ b/openspec/changes/generaliser-trigger-desastres/proposal.md
@@ -1,0 +1,110 @@
+## Why
+
+`desastres` est la seule capacité du corpus dont le comportement ne se vérifie pas de
+l'extérieur. Sur les 78 scénarios spécifiés, environ 68 s'assèrent par une simple requête
+HTTP ; ceux de `desastres` échappent au procédé, parce que quatorze règles sur vingt sont
+probabilistes et que rien ne permet de les forcer.
+
+Or **le mécanisme qui les forcerait existe déjà.** Le paramètre `trigger`, documenté dans
+`README-TRIGGER.adoc`, déclenche une règle depuis l'URL en court-circuitant *et* sa
+condition *et* sa probabilité :
+
+```php
+if ($triggerMatch) {
+  // Trigger present : application systematique
+  $shouldApply = true;
+}
+```
+
+Il n'a pas été conçu pour tester — il permettait de déclencher le jinglist à la demande —
+mais c'est exactement le geste requis. **Il est branché sur une règle sur vingt.**
+
+La démonstration de ce que coûte son absence vient d'être faite : trois chemins d'import
+invalides ont privé le site de quatre règles pendant sept mois, sans que rien ne le
+signale. Un `trigger` par règle aurait transformé ce diagnostic en une requête.
+
+## What Changes
+
+- **Chaque règle de désastre déclare un `trigger`.** Dix-neuf règles en reçoivent un ;
+  `tts_jinglist` conserve le sien.
+- Une convention de nommage est fixée, pour que le nom du déclencheur se déduise de la
+  règle plutôt que de s'inventer au cas par cas.
+- `README-TRIGGER.adoc` cesse de décrire une fonctionnalité ponctuelle pour décrire une
+  propriété de la configuration : toute règle est forçable.
+- **Aucun changement de comportement en production.** Un `trigger` n'a d'effet que si son
+  paramètre figure dans l'URL demandée. Sans lui, la règle s'évalue comme aujourd'hui :
+  même condition, même probabilité, même résultat.
+
+### Ce que cela rend possible
+
+```
+  GET /post/:slug?kraftwerk   →  la recette kraftwerk est-elle injectée avant </head> ?
+  GET /post/:slug?quickos     →  et celle-ci, un 3 août ?
+  GET /post/:slug             →  aucune des deux, sauf tirage
+```
+
+Le filtre `sfDesastreFilter` injecte avant `</head>` dans les réponses `text/html`. Le
+résultat est donc lisible dans le corps de la réponse, sans rien instrumenter, sans base
+de test, sans framework — ce qui compte sur un socle Symfony 1.5 dépourvu de suite de
+tests.
+
+La capacité `desastres` rejoint ainsi les cinq autres : vérifiable par requête. C'est le
+dernier obstacle à ce que le corpus de specs devienne un filet exécutable pour la
+migration du socle, qui est sa raison d'être.
+
+### Approche
+
+Le choix de généraliser un mécanisme existant plutôt que d'en introduire un autre —
+variable d'environnement, mode de test, graine `mt_srand()` fixée — tient au socle.
+Symfony 1.5 n'offre pas d'injection de dépendances exploitable ici, et `mt_rand()` est
+appelé directement dans `sfDesastreManager::findRecettes()`. Rendre cette ligne
+paramétrable supposerait de toucher au moteur ; `trigger` la contourne sans y toucher, et
+il est déjà écrit, déjà documenté, déjà éprouvé sur une règle.
+
+La contrepartie est assumée : les déclencheurs sont **publics**. N'importe quel visiteur
+peut forcer n'importe quel désastre en devinant un paramètre d'URL. Sur un site dont la
+raison d'être est le glitch et l'anarchie, ce n'est pas une faille — c'est au pire un jeu,
+et sans doute une bonne chose. Aucun désastre n'expose de donnée ni ne modifie d'état ;
+le pire cas est une redirection que le visiteur a lui-même demandée.
+
+## Hors périmètre
+
+- **L'écriture de la suite de vérification elle-même.** Ce changement rend `desastres`
+  vérifiable ; il ne construit pas l'outil qui la vérifie. Cet outil concernerait les six
+  capacités et non celle-ci seule, et mérite son propre changement.
+- Le moteur `sfDesastreRuleEngine`, qui n'est pas modifié. Il reste une fonction pure de
+  `query` et `context`, directement testable sans framework — c'est d'ailleurs ce qui
+  couvre les scénarios que `trigger` n'atteint pas.
+- Les probabilités, les conditions et les recettes, qui ne bougent pas d'un cheveu.
+- La correction des trois imports invalides et le doublon `postillons_mort`, traités par
+  `reparer-imports-desastres`. **Ce changement suppose ce correctif appliqué** : ajouter un
+  `trigger` à une règle qui ne se charge pas ne produirait rien.
+- Le rendu des désastres côté client — JavaScript, CSS, effets. `trigger` porte sur la
+  sélection des recettes, pas sur leur exécution dans le navigateur.
+
+## Capacités
+
+### Nouvelles capacités
+
+Aucune.
+
+### Capacités modifiées
+
+- `desastres` — le corpus décrit aujourd'hui le déclenchement conditionnel et la part
+  d'aléatoire (« Requirement: Déclenchement conditionnel », « Requirement: Part
+  d'aléatoire ») sans mentionner qu'une règle puisse être forcée. Une exigence est ajoutée
+  sur le forçage par paramètre d'URL, et la garantie que ce forçage n'altère rien en son
+  absence.
+
+## Impact
+
+- Les sept fichiers de `src/apps/frontend/config/desastres/regles/` : un champ `trigger`
+  par règle.
+- `src/apps/frontend/config/desastres/schemas/regles.schema.json`, si le champ doit y
+  devenir obligatoire — arbitrage laissé à l'implémentation.
+- `src/plugins/sfDesastrePlugin/README-TRIGGER.adoc` : portée du document.
+- **Contrat public inchangé en l'absence des paramètres.** Aucune route, aucun format,
+  aucune métadonnée. Une page demandée sans paramètre de déclenchement se comporte
+  exactement comme aujourd'hui.
+- Le dépôt gagne vingt paramètres d'URL non documentés côté visiteur, qui forcent chacun un
+  effet. Assumé, et cohérent avec l'esprit du site.

--- a/openspec/changes/generaliser-trigger-desastres/specs/desastres/spec.md
+++ b/openspec/changes/generaliser-trigger-desastres/specs/desastres/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Forçage d'une règle
+
+Toute règle de désastre SHALL être déclenchable depuis l'URL par un paramètre qui lui est
+propre, et ce forçage SHALL ignorer aussi bien la condition de la règle que sa
+probabilité.
+
+#### Scénario : Règle forcée par son paramètre
+
+- **QUAND** une demande de page porte le paramètre de déclenchement d'une règle
+- **ALORS** les recettes de cette règle sont appliquées à la réponse
+- **ET** ce, que la condition de la règle soit satisfaite ou non
+- **ET** quelle que soit la probabilité qu'elle déclare
+
+#### Scénario : Paramètre présent sans valeur
+
+- **QUAND** le paramètre de déclenchement figure dans l'URL sans valeur, ou avec une
+  valeur quelconque
+- **ALORS** la règle est déclenchée dans les deux cas, la seule présence du paramètre
+  valant déclenchement
+
+#### Scénario : Absence du paramètre
+
+- **QUAND** une demande de page ne porte aucun paramètre de déclenchement
+- **ALORS** chaque règle est évaluée par sa condition puis par sa probabilité, comme si
+  le mécanisme de forçage n'existait pas
+
+#### Scénario : Forçage de plusieurs règles
+
+- **QUAND** une demande porte les paramètres de déclenchement de plusieurs règles
+- **ALORS** les recettes de chacune sont appliquées à la réponse
+
+#### Scénario : Recette désactivée malgré le forçage
+
+- **QUAND** une règle est forcée mais que l'une de ses recettes est marquée désactivée en
+  configuration
+- **ALORS** cette recette n'est pas appliquée
+- **ET** le forçage porte sur la sélection de la règle, jamais sur l'activation d'une
+  recette
+
+### Requirement: Couverture des déclencheurs
+
+Chaque règle déclarée dans la configuration SHALL porter un paramètre de déclenchement, de
+sorte qu'aucun désastre ne soit observable seulement par tirage.
+
+#### Scénario : Règle sans déclencheur
+
+- **QUAND** la configuration comporte une règle qui ne déclare aucun paramètre de
+  déclenchement
+- **ALORS** cette règle est signalée comme non conforme à la configuration attendue
+
+#### Scénario : Unicité des déclencheurs
+
+- **QUAND** deux règles déclarent le même paramètre de déclenchement
+- **ALORS** ce paramètre les force toutes les deux, et cette ambiguïté est signalée

--- a/openspec/changes/reparer-imports-desastres/.openspec.yaml
+++ b/openspec/changes/reparer-imports-desastres/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: musique-approximative
+created: 2026-08-01
+goal: Corriger les trois chemins d'import invalides de desastres.yml et trancher
+  le doublon postillons_mort

--- a/openspec/changes/reparer-imports-desastres/proposal.md
+++ b/openspec/changes/reparer-imports-desastres/proposal.md
@@ -73,8 +73,25 @@ compromis défavorable.
 
 L'exigence retenue est donc **la visibilité, pas la rupture** : le système continue de
 servir la page, mais l'import non résolu doit être constatable autrement qu'en fouillant
-les journaux PHP d'un serveur de production. La forme exacte relève de l'implémentation ;
-le contrat est qu'un import déclaré et non résolu ne puisse pas passer inaperçu.
+les journaux PHP d'un serveur de production.
+
+**Tranché par le mainteneur : journaux et console.** Deux canaux, complémentaires par ce
+qu'ils atteignent :
+
+- **les journaux serveur** — l'`error_log` existant est conservé tel quel. C'est la trace
+  durable, celle qu'on relit après coup ;
+- **la console du navigateur** — un avertissement est émis dans la page, nommant les
+  imports déclarés qui ne se résolvent pas. C'est ce qui rend la panne constatable **sans
+  accès au serveur**, et donc ce qui aurait fait voir celle-ci en janvier plutôt qu'en
+  août.
+
+Le second canal emprunte le chemin déjà tracé : `sfDesastreFilter` injecte du JavaScript
+avant `</head>` dans les réponses `text/html`, et `injectDesastreOptions()` sait déjà
+produire un `<script>` inline. Rien de nouveau n'est à bâtir.
+
+Ce que ce choix implique et qu'il faut assumer : **l'avertissement est public**, visible
+par tout visiteur qui ouvre sa console. C'est cohérent avec le reste — les déclencheurs le
+seront aussi — et il ne divulgue qu'un chemin de fichier de configuration.
 
 ## Hors périmètre
 

--- a/openspec/changes/reparer-imports-desastres/proposal.md
+++ b/openspec/changes/reparer-imports-desastres/proposal.md
@@ -56,11 +56,12 @@ effet observable du doublon est donc la probabilité.** Aucun script ni feuille 
 double.
 
 La question à trancher n'est pas technique, elle est éditoriale : un morceau « mort »
-doit-il glitcher sept fois sur dix, ou neuf ? La proposition retenue est de **supprimer la
-copie de `misc.yml`** et de conserver celle de `postillons.yml`, où elle est à sa place
-thématique, en ramenant la probabilité à la valeur déclarée. Si les 0,91 étaient voulus,
-il faut alors l'écrire — `probability: 0.91` sur une règle unique — plutôt que de le
-laisser émerger d'une redondance que rien ne signale.
+doit-il glitcher sept fois sur dix, ou neuf ?
+
+**Tranché par le mainteneur : sept sur dix.** La copie de `misc.yml` est supprimée, celle
+de `postillons.yml` conservée — elle y est à sa place thématique — et la probabilité
+effective revient à la valeur que la règle annonce. Les 0,91 n'étaient pas voulus ; ils
+étaient le produit d'une redondance que rien ne signalait.
 
 ### Approche
 

--- a/openspec/changes/reparer-imports-desastres/proposal.md
+++ b/openspec/changes/reparer-imports-desastres/proposal.md
@@ -1,0 +1,119 @@
+## Why
+
+Trois des quatorze chemins d'import de `src/apps/frontend/config/desastres.yml` ne
+correspondent à aucun fichier. **Quatre règles de désastre sur vingt n'ont donc jamais été
+chargées**, depuis le commit `b3a7587` du 2 janvier 2026 qui a éclaté la configuration
+monolithique en modules. Les chemins ont été écrits en même temps que les fichiers et n'ont
+jamais concordé.
+
+L'écart est d'une lettre à chaque fois :
+
+| Import déclaré | Fichier présent | État |
+|---|---|---|
+| `desastres/regles/redirect.yml` | `regles/redirects.yml` | jamais chargé |
+| `desastres/regles/slitouine.yml` | `regles/splitouine.yml` | jamais chargé |
+| `desastres/recettes/slitouine.yml` | `recettes/splitouine.yml` | jamais chargé |
+
+L'échec est **silencieux**. `sfDesastreManager::processImports()` journalise un
+`error_log` et poursuit : la page est servie normalement, et le comportement observable
+d'un import cassé est identique à celui d'un fichier vide.
+
+Ce changement est daté. L'une des règles inertes est un œuf de Pâques de Noël —
+redirection vers *Quickos chante Noël* les 24 et 25 décembre. Écrite le 2 janvier 2026,
+huit jours après le Noël précédent, elle n'a pas encore eu une seule occasion de se
+déclencher : la première est **décembre 2026**. Corriger avant est la différence entre un
+bug attrapé et un bug constaté.
+
+## What Changes
+
+- Les trois chemins d'import fautifs sont corrigés, ce qui **ressuscite quatre règles** :
+  `spooky` (redirection sur *Spooky Mix*), `quickos` en décembre puis les 24 et 25, et
+  `catani` (désastre *splitouine*).
+- Un import qui ne résout pas **cesse d'échouer en silence**. C'est la seule modification
+  de comportement du plugin, et elle est ce qui empêche la panne de se reproduire : sans
+  elle, la prochaine faute de frappe mettra à son tour sept mois à se voir.
+- Le doublon de la règle `postillons_mort`, déclarée à l'identique dans `misc.yml` et
+  `postillons.yml`, est tranché — voir l'arbitrage ci-dessous.
+- Aucune recette n'est modifiée, aucune règle n'est ajoutée ni retirée par ailleurs.
+
+### L'arbitrage sur le doublon
+
+La règle `postillons_mort` figure deux fois, mot pour mot :
+
+```yaml
+- probability: 0.7
+  query: query.title ~ /.*(morte?s?|deaths?|dead).*/i
+  recettes: [postillons_mort]
+```
+
+`processImports()` fusionne les règles par `array_merge` sur une liste à index numériques
+— une concaténation, pas une déduplication. Les deux survivent, et `findRecettes()` tire
+deux fois. La probabilité effective n'est pas `0,7` mais `1 − 0,3² = 0,91`.
+
+Le reste de la chaîne est idempotent : `$allOptions` est clé par nom de désastre, et
+`addJavascript()` / `addStylesheet()` de Symfony 1.x dédoublonnent par chemin. **Le seul
+effet observable du doublon est donc la probabilité.** Aucun script ni feuille de style en
+double.
+
+La question à trancher n'est pas technique, elle est éditoriale : un morceau « mort »
+doit-il glitcher sept fois sur dix, ou neuf ? La proposition retenue est de **supprimer la
+copie de `misc.yml`** et de conserver celle de `postillons.yml`, où elle est à sa place
+thématique, en ramenant la probabilité à la valeur déclarée. Si les 0,91 étaient voulus,
+il faut alors l'écrire — `probability: 0.91` sur une règle unique — plutôt que de le
+laisser émerger d'une redondance que rien ne signale.
+
+### Approche
+
+Le plugin ne peut pas lever d'exception sur un import manquant sans risque : `desastres.yml`
+est chargé à chaque affichage de page, et une configuration fautive en production
+casserait le site entier plutôt que de le priver d'un effet. Sur un socle où le déploiement
+se fait par `rsync` et où rien ne valide la configuration avant mise en ligne, c'est un
+compromis défavorable.
+
+L'exigence retenue est donc **la visibilité, pas la rupture** : le système continue de
+servir la page, mais l'import non résolu doit être constatable autrement qu'en fouillant
+les journaux PHP d'un serveur de production. La forme exacte relève de l'implémentation ;
+le contrat est qu'un import déclaré et non résolu ne puisse pas passer inaperçu.
+
+## Hors périmètre
+
+- **La généralisation du paramètre `trigger`** à l'ensemble des règles, qui rendrait la
+  capacité vérifiable de l'extérieur et aurait fait apparaître ce bug en trente secondes.
+  C'est le changement `generaliser-trigger-desastres`, délibérément séparé : celui-ci est
+  un correctif daté, celui-là un geste structurel.
+- Le contenu des recettes, leurs scripts et leurs feuilles de style.
+- Les deux recettes `quickos` et `spooky`, qui se chargent aujourd'hui sans qu'aucune
+  règle ne les référence — `recettes/redirect.yml`, au singulier, existe bel et bien. Elles
+  cessent d'être orphelines du seul fait que leurs règles reviennent ; il n'y a rien à
+  faire de plus.
+- Les probabilités des seize règles qui fonctionnent, `postillons_mort` exceptée.
+- Le moteur de règles `sfDesastreRuleEngine`, qui n'est pas en cause.
+- Les cinq autres artefacts du dépôt qui décrivent sans contraindre. Ce changement en
+  traite un ; il ne préjuge pas des autres.
+
+## Capacités
+
+### Nouvelles capacités
+
+Aucune.
+
+### Capacités modifiées
+
+- `desastres` — le corpus décrit aujourd'hui l'absence totale de configuration
+  (« Requirement: Absence de configuration ») mais reste muet sur une configuration
+  **présente et partiellement invalide**. C'est précisément le cas qui s'est produit, et
+  celui qu'aucune exigence ne couvrait. Une exigence est ajoutée sur la résolution des
+  imports.
+
+## Impact
+
+- `src/apps/frontend/config/desastres.yml` : trois chemins d'import.
+- `src/apps/frontend/config/desastres/regles/misc.yml` : une règle en moins.
+- `src/plugins/sfDesastrePlugin/lib/sfDesastreManager.class.php` : traitement d'un import
+  non résolu.
+- **Le contrat public HTML change**, de façon volontaire et limitée : quatre règles
+  reviennent, donc certaines pages injecteront des ressources qu'elles n'injectaient pas.
+  Aucune route, aucun format de sortie, aucune métadonnée n'est touché — les désastres
+  n'agissent que sur les réponses `text/html`, via injection avant `</head>`.
+- Les visiteurs de *Spooky Mix* seront redirigés au bout de trois secondes, ce qui était
+  l'intention d'origine et ne l'a jamais été en fait.

--- a/openspec/changes/reparer-imports-desastres/specs/desastres/spec.md
+++ b/openspec/changes/reparer-imports-desastres/specs/desastres/spec.md
@@ -16,9 +16,14 @@ autant cesser de servir la page.
 
 - **QUAND** un chemin déclaré sous `imports` ne désigne aucun fichier
 - **ALORS** la page est servie normalement, avec les règles et recettes des imports valides
-- **ET** l'import non résolu est signalé autrement que par la seule journalisation du
-  serveur, de sorte qu'une configuration partiellement invalide ne puisse pas passer pour
-  une configuration complète
+- **ET** l'import non résolu est consigné dans les journaux du serveur
+- **ET** un avertissement nommant le chemin fautif est émis dans la console du navigateur,
+  de sorte que la panne soit constatable sans accès au serveur
+
+#### Scénario : Tous les imports valides
+
+- **QUAND** chaque chemin déclaré sous `imports` se résout
+- **ALORS** aucun avertissement n'est émis, ni dans les journaux, ni dans la console
 
 #### Scénario : Configuration partiellement invalide
 

--- a/openspec/changes/reparer-imports-desastres/specs/desastres/spec.md
+++ b/openspec/changes/reparer-imports-desastres/specs/desastres/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Résolution des imports
+
+Le système SHALL charger l'intégralité des fichiers de règles et de recettes déclarés en
+import, et SHALL rendre constatable tout import déclaré qui ne se résout pas, sans pour
+autant cesser de servir la page.
+
+#### Scénario : Tous les imports se résolvent
+
+- **QUAND** chaque chemin déclaré sous `imports` désigne un fichier existant
+- **ALORS** les règles et les recettes de tous ces fichiers participent à l'évaluation
+- **ET** l'ordre de déclaration détermine l'ordre d'évaluation des règles
+
+#### Scénario : Un import ne se résout pas
+
+- **QUAND** un chemin déclaré sous `imports` ne désigne aucun fichier
+- **ALORS** la page est servie normalement, avec les règles et recettes des imports valides
+- **ET** l'import non résolu est signalé autrement que par la seule journalisation du
+  serveur, de sorte qu'une configuration partiellement invalide ne puisse pas passer pour
+  une configuration complète
+
+#### Scénario : Configuration partiellement invalide
+
+- **QUAND** la configuration principale existe mais qu'une partie de ses imports est
+  introuvable
+- **ALORS** le système ne se comporte pas comme si les règles manquantes n'avaient jamais
+  été déclarées
+- **ET** l'écart entre ce qui est déclaré et ce qui est chargé est constatable
+
+### Requirement: Unicité des règles
+
+Le système SHALL évaluer chaque règle déclarée une fois et une seule, la probabilité
+annoncée par une règle valant pour l'ensemble de la configuration et non par fichier.
+
+#### Scénario : Règle déclarée dans deux fichiers importés
+
+- **QUAND** une même règle — condition, probabilité et recettes identiques — est déclarée
+  dans deux fichiers importés
+- **ALORS** sa probabilité effective de déclenchement est celle qu'elle annonce
+- **ET** non le résultat cumulé de plusieurs tirages indépendants
+
+#### Scénario : Recette sélectionnée plusieurs fois
+
+- **QUAND** plusieurs règles satisfaites désignent la même recette
+- **ALORS** ses ressources ne sont injectées qu'une fois dans la réponse
+- **ET** ses options ne sont transmises qu'une fois au désastre correspondant


### PR DESCRIPTION
## Ce que cette pull request contient

Deux propositions OpenSpec et leurs specs. **Ni tâches, ni code** — le travail est resté en mode exploration.

## 1. `reparer-imports-desastres` — un correctif daté

Trois des quatorze chemins d'import de `src/apps/frontend/config/desastres.yml` ne désignent aucun fichier :

| Import déclaré | Fichier présent |
|---|---|
| `desastres/regles/redirect.yml` | `regles/redirect**s**.yml` |
| `desastres/regles/slitouine.yml` | `regles/s**p**litouine.yml` |
| `desastres/recettes/slitouine.yml` | `recettes/s**p**litouine.yml` |

**Quatre règles sur vingt n'ont jamais été chargées** depuis le commit `b3a7587` du 2 janvier 2026, qui a éclaté la configuration monolithique en modules. Les chemins ont été écrits en même temps que les fichiers et n'ont jamais concordé.

L'échec est silencieux — `error_log`, puis la page se sert normalement. Le comportement observable d'un import cassé est identique à celui d'un fichier vide.

Les règles inertes : `spooky` (redirection sur *Spooky Mix*), `quickos` en décembre puis les 24 et 25, `catani`. Celle de Noël redirige vers *Quickos chante Noël* ; écrite le 2 janvier, huit jours après le Noël précédent, **sa première occasion est décembre 2026** — dans quatre mois.

S'y ajoute la règle `postillons_mort`, déclarée mot pour mot dans `misc.yml` et `postillons.yml`. La fusion des imports est une concaténation, pas une déduplication : elle est tirée deux fois, soit une probabilité effective de `1 − 0,3² = 0,91` au lieu des `0,7` annoncés. Le reste de la chaîne est idempotent — pas de script ni de CSS en double.

## 2. `generaliser-trigger-desastres` — le geste structurel

`desastres` est la seule des six capacités dont le comportement ne se vérifie pas de l'extérieur : quatorze règles sur vingt sont probabilistes.

Le mécanisme qui les forcerait **existe déjà**. Le paramètre `trigger`, documenté dans `README-TRIGGER.adoc`, déclenche une règle depuis l'URL en court-circuitant sa condition *et* sa probabilité. Il est branché sur une règle sur vingt.

L'étendre aux dix-neuf autres rend la capacité vérifiable par requête HTTP, sans base de test ni framework — ce qui compte sur un Symfony 1.5 dépourvu de suite de tests. Et cela aurait fait apparaître les imports cassés en trente secondes.

**Aucun changement de comportement en production** : un `trigger` n'a d'effet que si son paramètre figure dans l'URL demandée.

## Arbitrages posés dans les propositions

- **Le doublon** : supprimer la copie de `misc.yml`, ce qui ramène `postillons_mort` à sa probabilité déclarée. Si les 0,91 étaient voulus, il faut l'écrire plutôt que de le laisser émerger d'une redondance muette. **Décision éditoriale, elle revient au mainteneur.**
- **Ne pas lever d'exception** sur un import manquant. `desastres.yml` se charge à chaque affichage, le déploiement se fait par `rsync`, rien ne valide la configuration avant mise en ligne : une exception casserait le site entier au lieu de le priver d'un effet. L'exigence porte sur la visibilité, pas sur la rupture.
- **Les déclencheurs sont publics.** N'importe qui peut forcer n'importe quel désastre en devinant un paramètre. Sur ce site, au pire un jeu — mais cela se décide plutôt que de se subir.

## Dépendance

`generaliser-trigger-desastres` **suppose `reparer-imports-desastres` appliqué**. Ajouter un `trigger` à une règle qui ne se charge pas ne produirait rien.

## Hors périmètre des deux

La suite de vérification elle-même. Elle concernerait les six capacités et non `desastres` seule, et c'est le changement qui transformerait le corpus en filet exécutable pour la migration du socle. C'est le plus gros, et il reste à écrire.

## Vérification

`openspec validate --all` : 11 items, 0 échec.

Aucun fichier de `src/` n'est touché par cette pull request.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_