### PR TITLE
docs(openspec): acte l'arbitrage sur les déclencheurs publics

### DIFF
--- a/openspec/changes/generaliser-trigger-desastres/proposal.md
+++ b/openspec/changes/generaliser-trigger-desastres/proposal.md
@@ -62,10 +62,26 @@ paramétrable supposerait de toucher au moteur ; `trigger` la contourne sans y t
 il est déjà écrit, déjà documenté, déjà éprouvé sur une règle.
 
 La contrepartie est assumée : les déclencheurs sont **publics**. N'importe quel visiteur
-peut forcer n'importe quel désastre en devinant un paramètre d'URL. Sur un site dont la
-raison d'être est le glitch et l'anarchie, ce n'est pas une faille — c'est au pire un jeu,
-et sans doute une bonne chose. Aucun désastre n'expose de donnée ni ne modifie d'état ;
-le pire cas est une redirection que le visiteur a lui-même demandée.
+peut forcer n'importe quel désastre en devinant un paramètre d'URL.
+
+**Tranché par le mainteneur : publics.** Aucun mécanisme de secret — pas de jeton, pas de
+paramètre deviné long, pas de restriction à l'environnement de développement. Ce qui
+motive la décision, et qui vaut d'être écrit plutôt que sous-entendu :
+
+- **rien n'est exposé.** Aucun désastre ne lit de donnée ni ne modifie d'état. Le pire cas
+  est une redirection que le visiteur a lui-même demandée, ou une feuille de style qui
+  déforme sa propre page ;
+- **un secret aurait rendu la vérification plus fragile**, pas plus sûre : il faudrait le
+  transmettre à ce qui vérifie, donc le stocker quelque part, donc le voir dériver — le
+  mode de défaillance de ce dépôt, précisément ;
+- **sur ce site, c'est cohérent.** Un endroit dont la raison d'être est le glitch et
+  l'anarchie n'a pas de raison de cacher ses interrupteurs. Vingt paramètres devinables
+  qui déclenchent chacun un effet, ce n'est pas une faille — c'est un jeu, et il se trouve
+  qu'il sert aussi à tester.
+
+Cela suppose que les désastres à venir respectent la même règle : ne rien lire, ne rien
+modifier. Un désastre qui y dérogerait ne pourrait plus être forcé publiquement, et c'est
+alors le désastre qu'il faudrait revoir, pas le mécanisme.
 
 ## Hors périmètre
 

--- a/openspec/changes/generaliser-trigger-desastres/tasks.md
+++ b/openspec/changes/generaliser-trigger-desastres/tasks.md
@@ -1,0 +1,39 @@
+## 1. Convention de nommage
+
+- [ ] 1.1 Arrêter la règle de nommage d'un déclencheur, et l'écrire dans `README-TRIGGER.adoc`. La proposition : le nom de la recette principale de la règle, ce qui rend le déclencheur déductible plutôt qu'inventé — `?kraftwerk`, `?danse`, `?spooky`
+- [ ] 1.2 Traiter les deux cas où cette règle ne suffit pas : la règle `mangelettres` désigne deux recettes (`consonnard`, `voyelliste`), et `quickos` est désignée par deux règles distinctes — décembre, puis les 24 et 25. Deux déclencheurs sont donc nécessaires pour la seconde, faute de quoi un seul paramètre forcerait les deux règles et l'ambiguïté serait invérifiable
+- [ ] 1.3 Vérifier qu'aucun nom retenu n'entre en collision avec un paramètre déjà interprété par l'application : `format`, `c`, `q`, `current`, `embed`, `url`, `count`, `contributor`
+
+## 2. Déclaration des déclencheurs
+
+- [ ] 2.1 `regles/mamie.yml` — un déclencheur sur la règle `mamie_allo`
+- [ ] 2.2 `regles/mangelettres.yml` — un déclencheur sur la règle qui porte `consonnard` et `voyelliste`
+- [ ] 2.3 `regles/misc.yml` — neuf déclencheurs : `amour`, `robot`, `fish`, `postillons_mort`, `musique`, `bleu`, `noir`, `light`, `danse`. Une règle en moins si `reparer-imports-desastres` a été appliqué avant, ce qui est le cas nominal
+- [ ] 2.4 `regles/postillons.yml` — trois déclencheurs : `postillons_mort`, `kraftwerk`, `sale`
+- [ ] 2.5 `regles/redirects.yml` — trois déclencheurs : `spooky`, et deux distincts pour les deux règles `quickos`
+- [ ] 2.6 `regles/splitouine.yml` — un déclencheur sur la règle `catani`
+- [ ] 2.7 `regles/tts.yml` — un déclencheur sur `tts_rapper` ; `tts_jinglist` conserve le sien, `jinglist`, qui ne doit pas être renommé
+- [ ] 2.8 Recompter : vingt règles déclarées, vingt déclencheurs, aucun doublon
+
+## 3. Schéma et documentation
+
+- [ ] 3.1 Décider si `trigger` devient obligatoire dans `src/apps/frontend/config/desastres/schemas/regles.schema.json`. Le rendre obligatoire fait porter au schéma l'exigence « aucune règle sans déclencheur », ce que rien ne vérifierait autrement
+- [ ] 3.2 Réécrire `src/plugins/sfDesastrePlugin/README-TRIGGER.adoc` : le document décrit une fonctionnalité ponctuelle, il doit décrire une propriété de la configuration — toute règle est forçable, et voici la convention
+- [ ] 3.3 Documenter que les déclencheurs sont publics et pourquoi, avec la contrepartie : un désastre qui lirait une donnée ou modifierait un état ne pourrait plus être forcé publiquement
+
+## 4. Vérification manuelle
+
+> Chaque vérification suit le même geste : demander une page de morceau avec le paramètre,
+> et regarder ce qui est injecté avant `</head>` dans le HTML servi. Les ressources d'un
+> désastre `X` se reconnaissent aux chemins `/desastres/X/javascript/*.js` et
+> `/desastres/X/stylesheets/*.css`, et aux options dans `window.DesastreOptions`.
+
+- [ ] 4.1 Demander `/post/:slug?danse` sur un morceau dont le titre ne contient pas `danse`, et vérifier que le désastre est appliqué malgré la condition non satisfaite
+- [ ] 4.2 Demander `/post/:slug?kraftwerk` sur un morceau dont l'artiste n'est pas Kraftwerk — même attente
+- [ ] 4.3 Demander la même page **sans** paramètre, plusieurs fois, et vérifier que le désastre n'apparaît que selon sa probabilité. C'est le contrôle de non-régression qui compte : le forçage ne doit rien changer en son absence
+- [ ] 4.4 Demander `/post/:slug?quickos` un jour qui n'est ni le 24 ni le 25 décembre, et vérifier la redirection. C'est la vérification qui débloque la tâche 4.4 de `reparer-imports-desastres`, restée ouverte faute de pouvoir attendre décembre
+- [ ] 4.5 Demander `/post/:slug?bleu&noir` et vérifier que **les deux** désastres sont appliqués
+- [ ] 4.6 Demander un déclencheur avec une valeur — `?danse=1`, `?danse=true`, `?danse=nimportequoi` — et vérifier que les trois se comportent comme `?danse` seul
+- [ ] 4.7 Marquer temporairement une recette `enabled: false`, forcer sa règle, et vérifier qu'elle n'est **pas** appliquée : le forçage porte sur la sélection de la règle, jamais sur l'activation d'une recette. Rétablir ensuite
+- [ ] 4.8 Parcourir les vingt déclencheurs un à un et cocher cette tâche seulement quand les vingt ont été constatés. Si l'un d'eux ne produit rien, l'écrire ici plutôt que cocher — c'est exactement le genre de panne silencieuse que ce changement existe pour rendre visible
+- [ ] 4.9 Demander `/posts/feed?danse`, `/post/:slug?format=json&danse` et `/oembed?url=...&danse`, et vérifier qu'aucun désastre n'est injecté : les recettes ne s'appliquent qu'aux réponses `text/html`

--- a/openspec/changes/reparer-imports-desastres/tasks.md
+++ b/openspec/changes/reparer-imports-desastres/tasks.md
@@ -1,0 +1,34 @@
+## 1. Correction des chemins d'import
+
+- [ ] 1.1 Dans `src/apps/frontend/config/desastres.yml`, corriger `desastres/regles/redirect.yml` en `desastres/regles/redirects.yml`
+- [ ] 1.2 Corriger `desastres/regles/slitouine.yml` en `desastres/regles/splitouine.yml`
+- [ ] 1.3 Corriger `desastres/recettes/slitouine.yml` en `desastres/recettes/splitouine.yml`
+- [ ] 1.4 Relire les onze autres chemins un à un contre le contenu de `regles/` et `recettes/` — trois erreurs sur quatorze suggèrent que la liste n'a jamais été confrontée aux fichiers
+
+## 2. Doublon `postillons_mort`
+
+- [ ] 2.1 Supprimer de `src/apps/frontend/config/desastres/regles/misc.yml` la règle dont la condition est `query.title ~ /.*(morte?s?|deaths?|dead).*/i`, en conservant celle de `postillons.yml`
+- [ ] 2.2 Vérifier qu'aucune autre règle n'est déclarée deux fois : comparer les couples condition/recettes des sept fichiers de `regles/`
+
+## 3. Visibilité d'un import non résolu
+
+- [ ] 3.1 Dans `sfDesastreManager::processImports()`, retenir la liste des chemins déclarés qui ne se résolvent pas, au lieu de la perdre après l'`error_log`
+- [ ] 3.2 Conserver l'`error_log` existant tel quel — c'est la trace durable, et rien ne justifie de la changer
+- [ ] 3.3 Émettre un avertissement dans la console du navigateur nommant chaque chemin non résolu, en empruntant le chemin d'injection existant : `injectDesastreOptions()` produit déjà un `<script>` inline, et `sfDesastreFilter` l'insère avant `</head>` dans les réponses `text/html`
+- [ ] 3.4 S'assurer qu'aucun avertissement n'est émis lorsque tous les imports se résolvent — ni script inline supplémentaire, ni ligne de journal
+- [ ] 3.5 S'assurer que l'avertissement ne s'émet pas sur les réponses qui ne sont pas du HTML : `/posts/feed`, `format=json`, `format=xspf`, `format=max`, `/oembed`
+
+## 4. Vérification manuelle
+
+> Le désastre `quickos` ne peut pas être vérifié avant décembre : sa condition porte sur
+> `context.date.month == '12'`, et rien ne permet aujourd'hui de forcer une règle — c'est
+> précisément ce qu'apporte `generaliser-trigger-desastres`. La tâche 4.4 reste donc
+> ouverte, et son échéance est réelle.
+
+- [ ] 4.1 Sur une page de morceau quelconque, ouvrir la console du navigateur et vérifier qu'**aucun** avertissement de désastre n'apparaît — les quatorze imports se résolvent désormais
+- [ ] 4.2 Introduire volontairement une faute dans un chemin d'import, recharger une page de morceau, et vérifier que la console nomme le chemin fautif **et** que la page reste servie normalement. Rétablir le chemin ensuite
+- [ ] 4.3 Trouver un morceau dont l'artiste contient `catani`, demander `/post/:slug`, et vérifier dans le HTML servi que les ressources du désastre `splitouine` sont injectées avant `</head>`. La règle déclare `probability: 1` : elle doit se déclencher à chaque fois, sans exception. C'est la preuve que `regles/splitouine.yml` et `recettes/splitouine.yml` se chargent enfin. Si aucun morceau ne correspond, le noter ici plutôt que cocher
+- [ ] 4.4 **Bloquée jusqu'en décembre 2026.** Vérifier qu'un morceau demandé un 24 ou un 25 décembre redirige vers `quickoschantenoel.musiqueapproximative.net` au bout de trois secondes, une fois sur deux. À rouvrir à cette date, ou plus tôt si `generaliser-trigger-desastres` aboutit d'ici là
+- [ ] 4.5 Chercher un morceau dont le titre est exactement `Spooky Mix`, demander `/post/:slug`, et vérifier la redirection vers `sos.musiqueapproximative.net` — `probability: 1` là aussi. Si ce morceau n'existe pas au catalogue, le noter : la règle serait alors inerte pour une seconde raison, indépendante de celle que ce changement corrige
+- [ ] 4.6 Sur un morceau dont le titre contient `mort`, `death` ou `dead`, recharger une dizaine de fois et constater que le désastre `postillons_mort` ne se déclenche plus systématiquement. La vérification est statistique et donc faible : elle ne distingue pas 0,7 de 0,91 sur dix tirages. Elle ne vaut que comme contrôle grossier de non-régression
+- [ ] 4.7 Demander `/posts/feed`, `/post/:slug?format=json` et `/oembed?url=...`, et vérifier qu'aucun `<script>` de désastre n'apparaît dans ces réponses


### PR DESCRIPTION
## La décision

Les déclencheurs de désastres seront **publics**. Pas de jeton, pas de paramètre volontairement long, pas de restriction à l'environnement de développement. C'était le dernier arbitrage ouvert des deux propositions.

## Ce qui la motive

Trois raisons, écrites dans la proposition plutôt que sous-entendues :

- **Rien n'est exposé.** Aucun désastre ne lit de donnée ni ne modifie d'état. Le pire cas est une redirection que le visiteur a lui-même demandée, ou une feuille de style qui déforme sa propre page.
- **Un secret aurait rendu la vérification plus fragile, pas plus sûre.** Il faudrait le transmettre à ce qui vérifie, donc le stocker quelque part, donc le voir dériver — le mode de défaillance de ce dépôt, précisément. Six artefacts en ont déjà fait la démonstration.
- **C'est cohérent avec le site.** Un endroit dont la raison d'être est le glitch et l'anarchie n'a pas de raison de cacher ses interrupteurs. Vingt paramètres devinables qui déclenchent chacun un effet, c'est un jeu — et il se trouve qu'il sert aussi à tester.

## La contrepartie, posée explicitement

La décision suppose que les désastres à venir respectent la même règle : **ne rien lire, ne rien modifier**. Un désastre qui y dérogerait ne pourrait plus être forcé publiquement, et ce serait alors le désastre à revoir, pas le mécanisme.

## Modifications

`openspec/changes/generaliser-trigger-desastres/proposal.md`, section « Approche ».

Documentation seule. Aucun fichier de `src/` n'est touché.

## État des arbitrages

Les trois sont désormais tranchés :

| Arbitrage | Décision |
|---|---|
| Doublon `postillons_mort` | 0,7 — la copie de `misc.yml` est supprimée |
| Visibilité d'un import cassé | journaux serveur **et** console navigateur |
| Déclencheurs | publics |

Les deux propositions sont complètes. Ce qui leur manque désormais, ce sont leurs tâches — le geste qui les fait passer d'exploration à travail.

## Vérification

`openspec validate generaliser-trigger-desastres --type change` : valide.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_