### PR TITLE
fix(desastres): répare trois imports invalides et signale ceux qui ne résolvent pas

### DIFF
--- a/openspec/changes/reparer-imports-desastres/tasks.md
+++ b/openspec/changes/reparer-imports-desastres/tasks.md
@@ -52,15 +52,14 @@
 
 ## 4. Vérification manuelle
 
-> **Aucune de ces vérifications n'a pu être menée, et toutes les cases restent ouvertes.**
-> Le conteneur où ce changement a été implémenté n'a ni instance du site qui tourne, ni
-> base de données, ni le vendor Symfony installé. Les tâches 4.3 et 4.5 supposent en outre
-> l'existence de morceaux précis au catalogue — un artiste contenant `catani`, un titre
-> exactement égal à `Spooky Mix` — ce qui ne se sait pas d'ici.
+> **Les vérifications qui portent sur le correctif restent ouvertes : il n'est pas
+> déployé.** La production sert encore le code fautif, et le conteneur d'implémentation n'a
+> ni instance qui tourne, ni base de données, ni vendor Symfony. Ces cases se cocheront
+> après `make deploy`, pas avant.
 >
-> Ce qui a été vérifié à la place, et qui ne remplace rien : la logique modifiée, exercée
-> hors Symfony par un banc d'essai à bouchons (tâche 3.6), et la résolution des quatorze
-> chemins d'import confrontée aux fichiers (tâche 1.4).
+> **Ce qui a en revanche pu être établi contre la production**, et qui lève les deux
+> inconnues qui pesaient sur ce changement : les morceaux nécessaires existent, et le bug
+> est constaté en direct. Voir 4.8.
 >
 > Le désastre `quickos` reste par ailleurs invérifiable avant décembre : sa condition porte
 > sur `context.date.month == '12'`, et rien ne permet aujourd'hui de forcer une règle —
@@ -69,7 +68,35 @@
 - [ ] 4.1 Sur une page de morceau quelconque, ouvrir la console du navigateur et vérifier qu'**aucun** avertissement de désastre n'apparaît — les quatorze imports se résolvent désormais
 - [ ] 4.2 Introduire volontairement une faute dans un chemin d'import, recharger une page de morceau, et vérifier que la console nomme le chemin fautif **et** que la page reste servie normalement. Rétablir le chemin ensuite
 - [ ] 4.3 Trouver un morceau dont l'artiste contient `catani`, demander `/post/:slug`, et vérifier dans le HTML servi que les ressources du désastre `splitouine` sont injectées avant `</head>`. La règle déclare `probability: 1` : elle doit se déclencher à chaque fois, sans exception. C'est la preuve que `regles/splitouine.yml` et `recettes/splitouine.yml` se chargent enfin. Si aucun morceau ne correspond, le noter ici plutôt que cocher
+      — **le morceau existe** : `/post/patric-catani-le-split`. En production, avant
+      déploiement, **aucun désastre n'y est injecté** — ce qui confirme le bug (voir 4.8).
+      La case se coche quand `desastres/splitouine` apparaîtra sur cette page.
 - [ ] 4.4 **Bloquée jusqu'en décembre 2026.** Vérifier qu'un morceau demandé un 24 ou un 25 décembre redirige vers `quickoschantenoel.musiqueapproximative.net` au bout de trois secondes, une fois sur deux. À rouvrir à cette date, ou plus tôt si `generaliser-trigger-desastres` aboutit d'ici là
 - [ ] 4.5 Chercher un morceau dont le titre est exactement `Spooky Mix`, demander `/post/:slug`, et vérifier la redirection vers `sos.musiqueapproximative.net` — `probability: 1` là aussi. Si ce morceau n'existe pas au catalogue, le noter : la règle serait alors inerte pour une seconde raison, indépendante de celle que ce changement corrige
+      — **le morceau existe** : `/post/dumbshitthatjakazidmade-spooky-mix`, dont le titre
+      est exactement `Spooky Mix`. La condition `query.title == 'Spooky Mix'` porte donc
+      bien sur quelque chose. En production, aucun désastre n'y est injecté. La seconde
+      raison redoutée est écartée : la règle n'est inerte que par l'import cassé.
 - [ ] 4.6 Sur un morceau dont le titre contient `mort`, `death` ou `dead`, recharger une dizaine de fois et constater que le désastre `postillons_mort` ne se déclenche plus systématiquement. La vérification est statistique et donc faible : elle ne distingue pas 0,7 de 0,91 sur dix tirages. Elle ne vaut que comme contrôle grossier de non-régression
 - [ ] 4.7 Demander `/posts/feed`, `/post/:slug?format=json` et `/oembed?url=...`, et vérifier qu'aucun `<script>` de désastre n'apparaît dans ces réponses
+      — **état de référence relevé avant déploiement** : zéro occurrence de `desastres/`
+      ou `DesastreOptions` sur `/posts/feed` (`application/rss+xml`),
+      `?format=json` (`application/json`), `?format=max` (`application/maxmsp+text`) et
+      `/oembed` (`application/json+oembed`). La case se coche quand le même relevé sera
+      refait après déploiement, l'avertissement de console ne devant pas non plus y
+      apparaître.
+- [x] 4.8 **Constater le bug en production, avec témoin**, avant tout déploiement — c'est
+      ce qui distingue un diagnostic d'une conjecture
+      — fait le 2 août 2026 contre `https://www.musiqueapproximative.net` :
+
+      | Règle | `probability` | Fichier | Chargé ? | Désastre injecté ? |
+      |---|---|---|---|---|
+      | `danse` | 1 | `misc.yml` | oui | **`desastres/danse`** ✓ |
+      | `catani` | 1 | `splitouine.yml` | non | aucun |
+      | `spooky` | 1 | `redirects.yml` | non | aucun |
+
+      Le témoin est ce qui donne sa valeur au relevé : `danse` prouve que les désastres
+      fonctionnent en production. L'absence sur `catani` et `spooky` ne s'explique donc pas
+      par un plugin éteint ou un cache, mais bien par les imports non résolus. Les trois
+      règles déclarent `probability: 1` : aucune n'est soumise au hasard, et le résultat
+      est reproductible à chaque requête.

--- a/openspec/changes/reparer-imports-desastres/tasks.md
+++ b/openspec/changes/reparer-imports-desastres/tasks.md
@@ -1,29 +1,70 @@
 ## 1. Correction des chemins d'import
 
-- [ ] 1.1 Dans `src/apps/frontend/config/desastres.yml`, corriger `desastres/regles/redirect.yml` en `desastres/regles/redirects.yml`
-- [ ] 1.2 Corriger `desastres/regles/slitouine.yml` en `desastres/regles/splitouine.yml`
-- [ ] 1.3 Corriger `desastres/recettes/slitouine.yml` en `desastres/recettes/splitouine.yml`
-- [ ] 1.4 Relire les onze autres chemins un à un contre le contenu de `regles/` et `recettes/` — trois erreurs sur quatorze suggèrent que la liste n'a jamais été confrontée aux fichiers
+- [x] 1.1 Dans `src/apps/frontend/config/desastres.yml`, corriger `desastres/regles/redirect.yml` en `desastres/regles/redirects.yml`
+- [x] 1.2 Corriger `desastres/regles/slitouine.yml` en `desastres/regles/splitouine.yml`
+- [x] 1.3 Corriger `desastres/recettes/slitouine.yml` en `desastres/recettes/splitouine.yml`
+- [x] 1.4 Relire les onze autres chemins un à un contre le contenu de `regles/` et `recettes/` — trois erreurs sur quatorze suggèrent que la liste n'a jamais été confrontée aux fichiers
+      — les onze sont bons. Confronté par script : **quatorze chemins déclarés, zéro non
+      résolu.** Noter l'asymétrie qui a rendu la panne trompeuse : `recettes/redirect.yml`
+      est correct au singulier, alors que `regles/redirects.yml` prend un `s`. Les deux
+      fichiers ne portent pas le même nom, et ce n'est pas une faute — c'est ainsi.
 
 ## 2. Doublon `postillons_mort`
 
-- [ ] 2.1 Supprimer de `src/apps/frontend/config/desastres/regles/misc.yml` la règle dont la condition est `query.title ~ /.*(morte?s?|deaths?|dead).*/i`, en conservant celle de `postillons.yml`
-- [ ] 2.2 Vérifier qu'aucune autre règle n'est déclarée deux fois : comparer les couples condition/recettes des sept fichiers de `regles/`
+- [x] 2.1 Supprimer de `src/apps/frontend/config/desastres/regles/misc.yml` la règle dont la condition est `query.title ~ /.*(morte?s?|deaths?|dead).*/i`, en conservant celle de `postillons.yml`
+- [x] 2.2 Vérifier qu'aucune autre règle n'est déclarée deux fois : comparer les couples condition/recettes des sept fichiers de `regles/`
+      — aucun autre doublon. Confronté par script sur les sept fichiers : **dix-neuf règles
+      chargées, dix-neuf couples condition/recettes distincts.** Vingt étaient déclarées
+      avant ce changement, dont deux identiques.
 
 ## 3. Visibilité d'un import non résolu
 
-- [ ] 3.1 Dans `sfDesastreManager::processImports()`, retenir la liste des chemins déclarés qui ne se résolvent pas, au lieu de la perdre après l'`error_log`
-- [ ] 3.2 Conserver l'`error_log` existant tel quel — c'est la trace durable, et rien ne justifie de la changer
-- [ ] 3.3 Émettre un avertissement dans la console du navigateur nommant chaque chemin non résolu, en empruntant le chemin d'injection existant : `injectDesastreOptions()` produit déjà un `<script>` inline, et `sfDesastreFilter` l'insère avant `</head>` dans les réponses `text/html`
-- [ ] 3.4 S'assurer qu'aucun avertissement n'est émis lorsque tous les imports se résolvent — ni script inline supplémentaire, ni ligne de journal
-- [ ] 3.5 S'assurer que l'avertissement ne s'émet pas sur les réponses qui ne sont pas du HTML : `/posts/feed`, `format=json`, `format=xspf`, `format=max`, `/oembed`
+- [x] 3.1 Dans `sfDesastreManager::processImports()`, retenir la liste des chemins déclarés qui ne se résolvent pas, au lieu de la perdre après l'`error_log`
+      — propriété `$unresolvedImports`, réinitialisée à chaque `processImports()`, exposée
+      par `getUnresolvedImports()`.
+- [x] 3.2 Conserver l'`error_log` existant tel quel — c'est la trace durable, et rien ne justifie de la changer
+      — les deux appels sont intacts, à la ligne près. Une seule ligne est ajoutée après
+      chacun.
+- [x] 3.3 Émettre un avertissement dans la console du navigateur nommant chaque chemin non résolu, en empruntant le chemin d'injection existant : `injectDesastreOptions()` produit déjà un `<script>` inline, et `sfDesastreFilter` l'insère avant `</head>` dans les réponses `text/html`
+      — `injectUnresolvedImportsWarning()`, appelée depuis `applyToRequest()` **hors** du
+      test `if (!empty($recettes))`. C'était le point à ne pas manquer : une configuration
+      cassée doit se voir même quand aucune règle ne se déclenche, or `applyRecettesToResponse()`
+      n'est appelée que lorsqu'une recette s'applique.
+      — Le filtre lit un troisième attribut, `desastre_warnings_js`, à côté des deux
+      existants.
+- [x] 3.4 S'assurer qu'aucun avertissement n'est émis lorsque tous les imports se résolvent — ni script inline supplémentaire, ni ligne de journal
+      — l'attribut est **toujours écrit**, à `null` quand il n'y a rien à dire. Les
+      attributs utilisateur de Symfony 1.x persistent en session : sans cette écriture, un
+      avertissement émis avant la correction d'un chemin survivrait à cette correction.
+- [x] 3.5 S'assurer que l'avertissement ne s'émet pas sur les réponses qui ne sont pas du HTML : `/posts/feed`, `format=json`, `format=xspf`, `format=max`, `/oembed`
+      — acquis par construction, sans code supplémentaire : `sfDesastreFilter` teste déjà
+      le type de contenu et ne touche qu'aux réponses HTML. `apply_desastre()` n'est du
+      reste appelée que depuis `executeShow()` et `executeList()`.
+- [x] 3.6 Exercer la logique hors Symfony, le vendor n'étant pas installé
+      — banc d'essai avec bouchons pour `sfYaml`, `sfContext` et l'utilisateur, appelant
+      `processImports()` et `injectUnresolvedImportsWarning()` par réflexion. Quatre cas,
+      tous verts : configuration réelle sans faute, deux chemins fautifs relevés tous les
+      deux, attribut à `null` quand tout résout, `console.warn` nommant les deux chemins
+      sinon. `php -l` passe sur les deux fichiers modifiés.
+      — Le banc n'est **pas versé au dépôt** : il vaut comme preuve d'exécution ici, pas
+      comme suite de tests. Lui donner une place durable dépasse ce changement — et
+      mériterait le sien, `src/test/` existant déjà sans être utilisé.
 
 ## 4. Vérification manuelle
 
-> Le désastre `quickos` ne peut pas être vérifié avant décembre : sa condition porte sur
-> `context.date.month == '12'`, et rien ne permet aujourd'hui de forcer une règle — c'est
-> précisément ce qu'apporte `generaliser-trigger-desastres`. La tâche 4.4 reste donc
-> ouverte, et son échéance est réelle.
+> **Aucune de ces vérifications n'a pu être menée, et toutes les cases restent ouvertes.**
+> Le conteneur où ce changement a été implémenté n'a ni instance du site qui tourne, ni
+> base de données, ni le vendor Symfony installé. Les tâches 4.3 et 4.5 supposent en outre
+> l'existence de morceaux précis au catalogue — un artiste contenant `catani`, un titre
+> exactement égal à `Spooky Mix` — ce qui ne se sait pas d'ici.
+>
+> Ce qui a été vérifié à la place, et qui ne remplace rien : la logique modifiée, exercée
+> hors Symfony par un banc d'essai à bouchons (tâche 3.6), et la résolution des quatorze
+> chemins d'import confrontée aux fichiers (tâche 1.4).
+>
+> Le désastre `quickos` reste par ailleurs invérifiable avant décembre : sa condition porte
+> sur `context.date.month == '12'`, et rien ne permet aujourd'hui de forcer une règle —
+> c'est précisément ce qu'apporte `generaliser-trigger-desastres`. Son échéance est réelle.
 
 - [ ] 4.1 Sur une page de morceau quelconque, ouvrir la console du navigateur et vérifier qu'**aucun** avertissement de désastre n'apparaît — les quatorze imports se résolvent désormais
 - [ ] 4.2 Introduire volontairement une faute dans un chemin d'import, recharger une page de morceau, et vérifier que la console nomme le chemin fautif **et** que la page reste servie normalement. Rétablir le chemin ensuite

--- a/src/apps/frontend/config/desastres.yml
+++ b/src/apps/frontend/config/desastres.yml
@@ -12,15 +12,15 @@ imports:
     - desastres/recettes/misc.yml
     - desastres/recettes/postillons.yml
     - desastres/recettes/redirect.yml
-    - desastres/recettes/slitouine.yml
+    - desastres/recettes/splitouine.yml
     - desastres/recettes/tts.yml
   regles:
     - desastres/regles/mamie.yml
     - desastres/regles/mangelettres.yml
     - desastres/regles/misc.yml
     - desastres/regles/postillons.yml
-    - desastres/regles/redirect.yml
-    - desastres/regles/slitouine.yml
+    - desastres/regles/redirects.yml
+    - desastres/regles/splitouine.yml
     - desastres/regles/tts.yml
 
 # On peut aussi definir des regles/recettes directement ici

--- a/src/apps/frontend/config/desastres/regles/misc.yml
+++ b/src/apps/frontend/config/desastres/regles/misc.yml
@@ -12,9 +12,6 @@ regles:
     query: query.title ~ /.*(fish|poisson).*/i
     recettes: [fish]
   - probability: 0.7
-    query: query.title ~ /.*(morte?s?|deaths?|dead).*/i
-    recettes: [postillons_mort]
-  - probability: 0.7
     query: query.title ~ /.*(musique|music).*/i
     recettes: [musique]
   - probability: 0.7

--- a/src/plugins/sfDesastrePlugin/lib/filter/sfDesastreFilter.class.php
+++ b/src/plugins/sfDesastrePlugin/lib/filter/sfDesastreFilter.class.php
@@ -29,8 +29,9 @@ class sfDesastreFilter extends sfFilter
     $user = $this->context->getUser();
     $jsCode = $user->getAttribute('desastre_options_js', null);
     $cssCode = $user->getAttribute('desastre_options_css', null);
+    $warningsCode = $user->getAttribute('desastre_warnings_js', null);
 
-    if (!$jsCode && !$cssCode) {
+    if (!$jsCode && !$cssCode && !$warningsCode) {
       return;
     }
 
@@ -55,6 +56,9 @@ class sfDesastreFilter extends sfFilter
       }
       if ($jsCode) {
         $inject .= $jsCode . "\n";
+      }
+      if ($warningsCode) {
+        $inject .= $warningsCode . "\n";
       }
 
       $content = str_replace('</head>', $inject . '</head>', $content);

--- a/src/plugins/sfDesastrePlugin/lib/sfDesastreManager.class.php
+++ b/src/plugins/sfDesastrePlugin/lib/sfDesastreManager.class.php
@@ -16,6 +16,19 @@ class sfDesastreManager
   protected $ruleEngine = null;
 
   /**
+   * Chemins declares sous "imports" qui ne designent aucun fichier.
+   *
+   * Un import non resolu ne fait pas echouer le chargement : la page reste
+   * servie, avec les regles et recettes des imports valides. Il faut donc
+   * conserver la liste pour la signaler, faute de quoi une configuration
+   * partiellement invalide se comporte exactement comme une configuration
+   * complete.
+   *
+   * @var array
+   */
+  protected $unresolvedImports = array();
+
+  /**
    * Constructeur
    *
    * @param string|array $config Chemin vers le fichier YAML de configuration ou tableau de configuration
@@ -70,6 +83,8 @@ class sfDesastreManager
     $imports = isset($config['imports']) ? $config['imports'] : array();
     unset($config['imports']);
 
+    $this->unresolvedImports = array();
+
     // Initialiser les tableaux si non definis
     if (!isset($config['regles'])) {
       $config['regles'] = array();
@@ -90,6 +105,7 @@ class sfDesastreManager
         } else {
           // Log warning mais ne pas echouer
           error_log(sprintf('[sfDesastreManager] WARNING: Import file not found: %s', $fullPath));
+          $this->unresolvedImports[] = $importPath;
         }
       }
     }
@@ -106,11 +122,22 @@ class sfDesastreManager
           }
         } else {
           error_log(sprintf('[sfDesastreManager] WARNING: Import file not found: %s', $fullPath));
+          $this->unresolvedImports[] = $importPath;
         }
       }
     }
 
     return $config;
+  }
+
+  /**
+   * Retourne les chemins declares sous "imports" qui ne designent aucun fichier.
+   *
+   * @return array Tableau de chemins relatifs, vide si tous les imports resolvent
+   */
+  public function getUnresolvedImports()
+  {
+    return $this->unresolvedImports;
   }
 
   /**
@@ -216,6 +243,44 @@ class sfDesastreManager
     if (!empty($recettes)) {
       $this->applyRecettesToResponse($response, $recettes, $webRoot, $fsRoot, $context);
     }
+
+    // Signaler les imports non resolus, qu'une recette s'applique ou non :
+    // une configuration cassee doit se voir meme quand aucune regle ne matche.
+    $this->injectUnresolvedImportsWarning($context);
+  }
+
+  /**
+   * Emet un avertissement dans la console du navigateur pour chaque import non resolu.
+   *
+   * L'attribut est toujours ecrit, y compris a vide : les attributs utilisateur de
+   * Symfony 1.x persistent en session, et un avertissement d'une requete precedente
+   * survivrait sinon a la correction du chemin fautif.
+   *
+   * L'injection elle-meme est faite par sfDesastreFilter, qui n'ecrit que dans les
+   * reponses HTML : les formats json, xspf, max, le flux et oEmbed sont donc epargnes
+   * sans qu'il y ait rien a verifier ici.
+   *
+   * @param sfContext $context Contexte Symfony (optionnel)
+   */
+  protected function injectUnresolvedImportsWarning(sfContext $context = null)
+  {
+    if ($context === null) {
+      return;
+    }
+
+    $jsCode = null;
+
+    if (!empty($this->unresolvedImports)) {
+      $jsCode = '<script type="text/javascript">' . "\n";
+      $jsCode .= '/* Desastre - Auto-generated */' . "\n";
+      $jsCode .= 'console.warn(' . json_encode(sprintf(
+        'Désastres : %d import(s) déclaré(s) dans desastres.yml ne désignent aucun fichier. Les règles et recettes qu\'ils portent ne sont pas chargées.',
+        count($this->unresolvedImports)
+      )) . ', ' . json_encode(array_values($this->unresolvedImports)) . ');' . "\n";
+      $jsCode .= '</script>';
+    }
+
+    $context->getUser()->setAttribute('desastre_warnings_js', $jsCode);
   }
 
   /**


### PR DESCRIPTION
Implémente `reparer-imports-desastres`, sections 1 à 3. **13 tâches sur 20.** Les vérifications qui portent sur le correctif restent ouvertes : il n'est pas déployé.

## Le correctif

Trois des quatorze chemins d'import de `desastres.yml` ne désignaient aucun fichier :

| Déclaré | Fichier réel |
|---|---|
| `regles/redirect.yml` | `regles/redirect**s**.yml` |
| `regles/slitouine.yml` | `regles/s**p**litouine.yml` |
| `recettes/slitouine.yml` | `recettes/s**p**litouine.yml` |

**Quatre règles sur vingt n'avaient jamais été chargées** depuis le commit `b3a7587` du 2 janvier 2026 : `spooky`, `quickos` deux fois, `catani`.

Les onze autres chemins ont été confrontés aux fichiers : tous bons. À noter, parce que c'est ce qui rendait la panne trompeuse — `recettes/redirect.yml` est correct **au singulier**, alors que `regles/redirects.yml` prend un `s`. Les deux fichiers ne portent pas le même nom, et ce n'est pas une faute.

## Le bug constaté en production, avec témoin

Relevé contre `https://www.musiqueapproximative.net` avant tout déploiement :

| Règle | `probability` | Fichier | Chargé ? | Désastre injecté ? |
|---|---|---|---|---|
| `danse` | 1 | `misc.yml` | oui | **`desastres/danse`** ✓ |
| `catani` | 1 | `splitouine.yml` | non | aucun |
| `spooky` | 1 | `redirects.yml` | non | aucun |

Le témoin est ce qui donne sa valeur au relevé : `danse` prouve que les désastres fonctionnent en production. L'absence sur les deux autres ne s'explique donc ni par un plugin éteint, ni par un cache. Les trois règles déclarent `probability: 1` — aucune n'est soumise au hasard, et le résultat est reproductible à chaque requête.

Les deux inconnues qui pesaient sur les vérifications sont levées : `/post/patric-catani-le-split` existe, et `/post/dumbshitthatjakazidmade-spooky-mix` porte exactement le titre `Spooky Mix`. La règle `spooky` n'était donc pas inerte pour une seconde raison.

## Le doublon

`postillons_mort` était déclarée mot pour mot dans `misc.yml` et `postillons.yml`. La fusion des imports est une concaténation, pas une déduplication : deux tirages indépendants, soit `1 − 0,3² = 0,91` au lieu des `0,7` annoncés. La copie de `misc.yml` est retirée.

Vérifié par script sur les sept fichiers : **dix-neuf règles, dix-neuf couples condition/recettes distincts.**

## La visibilité

`sfDesastreManager` retient les chemins non résolus et les nomme dans un `console.warn`, injecté par le filtre existant avant la fermeture du `head`. L'`error_log` reste intact — c'est la trace durable.

Deux points qui ne sautent pas aux yeux et qui sont l'essentiel du travail :

- **l'appel est fait hors du test `if (!empty($recettes))`.** `applyRecettesToResponse()` n'est invoquée que lorsqu'une recette s'applique ; une configuration cassée doit se voir même quand aucune règle ne se déclenche ;
- **l'attribut est toujours écrit, à `null` quand il n'y a rien à dire.** Les attributs utilisateur de Symfony 1.x persistent en session : sans cette écriture, un avertissement émis avant la correction d'un chemin survivrait à cette correction.

Rien n'est injecté hors HTML : `sfDesastreFilter` teste déjà le type de contenu, et `apply_desastre()` n'est appelée que depuis `executeShow()` et `executeList()`.

## Ce qui a été vérifié, et ce qui ne l'a pas été

`php -l` passe sur les deux fichiers modifiés. La logique a été exercée hors Symfony — le vendor n'est pas installé dans ce conteneur — par un banc d'essai à bouchons appelant `processImports()` et `injectUnresolvedImportsWarning()` par réflexion. Quatre cas, tous verts : configuration réelle sans faute, deux chemins fautifs relevés tous les deux, attribut à `null` quand tout résout, `console.warn` nommant les deux chemins sinon.

**Cela ne remplace pas les vérifications manuelles du correctif, qui restent ouvertes** faute d'instance qui tourne dans ce conteneur. Le fichier de tâches dit lesquelles et pourquoi.

Le banc d'essai n'est pas versé au dépôt : il vaut comme preuve d'exécution, pas comme suite de tests. Lui donner une place durable dépasse ce changement, et `src/test/` existe déjà sans être utilisé.

## L'échéance qui demeure

`quickos` reste invérifiable avant décembre — sa condition porte sur le mois, et rien ne permet encore de forcer une règle. C'est `generaliser-trigger-desastres` qui débloquera cette vérification, en permettant de demander `?quickos` un jour d'août.

## Impact

Le contrat public HTML change, volontairement : quatre règles reviennent, donc certaines pages injecteront des ressources qu'elles n'injectaient pas. Aucune route, aucun format de sortie, aucune métadonnée n'est touché.

`openspec validate --all` : 11 items, 0 échec.