### PR TITLE
fix(formats): rétablit le format XSPF, cassé en production

### DIFF
--- a/openspec/changes/reparer-format-xspf/.openspec.yaml
+++ b/openspec/changes/reparer-format-xspf/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: musique-approximative
+created: 2026-08-02
+goal: Réparer le format XSPF, qui renvoie une erreur 500 sur les deux routes, et
+  corriger l'exigence du corpus sur les formats annoncés

--- a/openspec/changes/reparer-format-xspf/proposal.md
+++ b/openspec/changes/reparer-format-xspf/proposal.md
@@ -1,0 +1,132 @@
+## Why
+
+**Le format XSPF renvoie une erreur 500 avec un corps vide**, sur les deux routes qui le
+proposent. Relevé le 2 août 2026 contre la production :
+
+| Requête | Statut | Type de contenu | Taille |
+|---|---|---|---|
+| `/posts` | 200 | `text/html` | 3 701 373 o |
+| `/posts?format=json` | 200 | `application/json` | 7 947 865 o |
+| `/posts?format=max` | 200 | `application/maxmsp+text` | 2 509 715 o |
+| `/posts?format=xspf` | **500** | `text/html` | **0 o** |
+
+`/post/:slug?format=xspf` échoue de même. Les trois autres formats fonctionnent.
+
+Ce n'est pas un coin obscur : la page de liste **annonce elle-même** ce format, par un
+`<link rel="alternate" type="application/xspf+xml">` et par un lien visible sous
+« Servez-vous ! ». Le site propose donc au visiteur, et à tout agrégateur qui lit ses
+métadonnées, une adresse qui échoue.
+
+L'écart n'a été vu que parce que le corpus de specs le rendait lisible. Sans exigence
+écrite sur les types de contenu, un 500 sur un format de playlist passait pour normal.
+
+### Deux causes distinctes, pour un même symptôme
+
+**Sur la liste** — `listSuccess.xspf.php` charge une dépendance PEAR :
+
+```php
+set_include_path(get_include_path().':/usr/share/php');
+require('File/XSPF.php');
+```
+
+Le `Dockerfile` installe `bash curl gettext git make zip` et les extensions `opcache` et
+`pdo_mysql`. **Ni PEAR, ni `File_XSPF`.** Le `require` échoue fatalement, d'où le 500 au
+corps vide. La dépendance existait sans doute sur l'hébergement d'origine ; elle n'a jamais
+été portée dans l'image.
+
+**Sur un morceau isolé** — il n'existe aucun gabarit `showSuccess.xspf.php`. Les autres
+sont là : `showSuccess.json.php`, `showSuccess.max.php`, `showSuccess.php`. Symfony ne
+trouve pas la vue et échoue.
+
+## What Changes
+
+- Le format XSPF **sert un document XSPF valide**, en `application/xspf+xml`, sur
+  `/posts` comme sur `/post/:slug`.
+- La dépendance à PEAR `File_XSPF` est levée. XSPF est un format XML de quelques
+  éléments ; le produire directement supprime une dépendance système invisible du
+  `composer.json`, absente de l'image, et dont l'échec est muet.
+- Un gabarit de morceau isolé est ajouté, à l'image de ce que `json` et `max` font déjà :
+  une playlist d'un seul élément.
+- **Correction d'une exigence fausse du corpus.** Voir ci-dessous : ce n'est pas le code
+  qui dévie de la spec sur ce point, c'est la spec qui décrit mal le code.
+
+### L'exigence du corpus était inexacte
+
+Le corpus affirme aujourd'hui :
+
+> **QUAND** une page de morceau ou de liste est servie en HTML
+> **ALORS** les formats `json` et `xspf` sont annoncés au visiteur
+> **ET** le format `max` ne l'est pas, bien qu'il reste accessible
+
+Confronté au code et à la production, c'est faux sur deux points :
+
+- **une page de morceau n'annonce que `json`.** `executeShow()` construit un
+  `$formatsLimited` qui ne contient que lui — c'est délibéré, le commentaire dit
+  « Formats specifics ». `xspf` et `max` n'y sont annoncés ni en `<link>`, ni au visiteur ;
+- **`max` est bien annoncé sur la liste**, en `<link rel="alternate">`. Le drapeau
+  `display` ne gouverne que les liens visibles du pied de page, pas les métadonnées.
+
+La distinction entre ces deux canaux — `<link>` d'un côté, liens visibles de l'autre —
+n'existait pas dans l'exigence. Elle y entre.
+
+Ce point mérite d'être noté pour lui-même : **le corpus a dérivé dès sa rédaction**, dans
+la séance même qui l'a produit. Il a été écrit en lisant le code, sans le confronter à une
+instance qui tourne. C'est le mode de défaillance de ce dépôt, et le corpus n'y échappe
+pas — il l'attrape seulement plus vite, parce qu'il est vérifiable.
+
+### Approche
+
+Deux voies s'offraient pour la dépendance : installer PEAR et `File_XSPF` dans l'image, ou
+produire le XML directement.
+
+La seconde est retenue. `File_XSPF` est une bibliothèque PEAR sans version publiée depuis
+plus de quinze ans, absente du `composer.json`, invisible de quiconque lit les dépendances
+déclarées du projet, et dont l'absence ne se manifeste que par un 500 muet en production.
+L'ajouter à l'image reconduirait exactement le problème que ce dépôt collectionne : une
+chose dont dépend le comportement, et que rien ne rend visible.
+
+Un document XSPF de playlist tient en une poignée d'éléments — `title`, `date`, puis un
+`track` par morceau avec `location`, `creator`, `title`, `annotation`, `info`. Le produire
+avec les outils XML de PHP est plus court que la dépendance qu'il remplace.
+
+La contrainte du socle qui oriente ce choix : sur Symfony 1.5 et PHP 7.4, une dépendance
+système non déclarée ne casse qu'au moment du rendu, dans une vue, sans que rien en amont
+ne l'ait signalée. Moins il y en a, mieux le legacy se porte.
+
+## Hors périmètre
+
+- **Les autres formats.** `json`, `max` et le flux RSS fonctionnent et ne sont pas touchés.
+- **Le choix d'annoncer ou non tel format sur telle page.** Ce changement décrit ce que
+  fait le code, il ne rearbitre pas. Si `xspf` devait être annoncé sur une page de morceau,
+  ce serait un autre changement, et une décision éditoriale.
+- **`showSuccess.csv.php`**, gabarit présent au dépôt alors qu'aucun format `csv` n'est
+  déclaré dans `setFormats()`. Repéré à l'occasion — un huitième artefact qui décrit sans
+  contraindre. Son sort mérite son propre changement.
+- La validation du document produit contre le schéma XSPF officiel, qui suppose un
+  outillage que le dépôt n'a pas.
+- Le contenu même de la playlist — quels morceaux, dans quel ordre, avec quels champs.
+  Ce changement rétablit un format cassé, il ne le redessine pas.
+
+## Capacités
+
+### Nouvelles capacités
+
+Aucune.
+
+### Capacités modifiées
+
+- `formats-de-sortie` — l'exigence « Sélection du format » est corrigée sur deux points :
+  ce qu'un format déclaré garantit lorsqu'il est demandé, et lesquels sont réellement
+  annoncés, sur quelle page, par quel canal.
+
+## Impact
+
+- `src/apps/frontend/modules/post/templates/listSuccess.xspf.php` : réécrit sans PEAR.
+- `src/apps/frontend/modules/post/templates/showSuccess.xspf.php` : créé.
+- **Contrat public rétabli, non modifié.** `application/xspf+xml` est ce que le site
+  annonce déjà ; il cessera simplement de mentir. Aucune route ne bouge, aucun autre
+  format n'est touché.
+- Les agrégateurs et lecteurs qui suivent le `<link rel="alternate">` de la page de liste
+  obtiendront une playlist au lieu d'une erreur. Combien sont-ils, on l'ignore : rien ne
+  mesure l'usage de ce format, et il est cassé depuis assez longtemps pour que les usagers
+  éventuels aient renoncé.

--- a/openspec/changes/reparer-format-xspf/specs/formats-de-sortie/spec.md
+++ b/openspec/changes/reparer-format-xspf/specs/formats-de-sortie/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: Sélection du format
+
+Le système SHALL servir une représentation alternative lorsque le paramètre `format`
+désigne un format connu, et SHALL déclarer le type de contenu correspondant. Un format
+déclaré SHALL aboutir : il ne peut ni échouer, ni servir un corps vide.
+
+#### Scénario : Formats reconnus
+
+- **QUAND** un consommateur ajoute `format=json`, `format=xspf` ou `format=max` à une
+  demande de morceau ou de liste
+- **ALORS** la réponse est servie sans gabarit d'habillage
+- **ET** le type de contenu est respectivement `application/json`,
+  `application/xspf+xml` ou `application/maxmsp+text`
+- **ET** le corps n'est pas vide
+
+#### Scénario : Un format déclaré aboutit toujours
+
+- **QUAND** un format figure dans la liste des formats connus du système
+- **ALORS** il est servi avec un code `200` sur `/posts` comme sur `/post/:slug`
+- **ET** aucune dépendance absente de l'environnement d'exécution ne peut le faire échouer
+  silencieusement
+
+#### Scénario : Format inconnu
+
+- **QUAND** le paramètre `format` désigne une valeur non reconnue
+- **ALORS** la page est servie dans sa représentation HTML habituelle
+
+#### Scénario : Formats annoncés sur une page de liste
+
+- **QUAND** une page de liste est servie en HTML
+- **ALORS** `json`, `xspf` et `max` sont déclarés en `<link rel="alternate">`, chacun avec
+  son type de contenu
+- **ET** seuls `json` et `xspf` figurent parmi les liens visibles proposés au visiteur
+
+#### Scénario : Formats annoncés sur une page de morceau
+
+- **QUAND** une page de morceau est servie en HTML
+- **ALORS** `json` est le seul format annoncé, en `<link rel="alternate">` comme parmi les
+  liens visibles
+- **ET** `xspf` et `max` restent accessibles par le paramètre `format`, sans être annoncés
+
+### Requirement: Représentation XSPF d'une liste
+
+La représentation XSPF SHALL être un document de playlist valide, portant un titre décrivant
+la sélection demandée et un élément par morceau.
+
+#### Scénario : Document servi
+
+- **QUAND** un consommateur demande une liste au format `xspf`
+- **ALORS** la racine du document est une playlist XSPF
+- **ET** le document déclare l'encodage `utf-8`
+- **ET** le type de contenu est `application/xspf+xml`
+
+#### Scénario : Titre de la playlist
+
+- **QUAND** la liste est filtrée par contributeur
+- **ALORS** le titre de la playlist nomme ce contributeur
+- **ET** lorsque la liste est filtrée par recherche, le titre reprend le terme cherché
+- **ET** sans filtre, le titre désigne l'ensemble des morceaux
+
+#### Scénario : Description d'un morceau
+
+- **QUAND** un morceau figure dans la playlist
+- **ALORS** son élément porte l'adresse absolue du fichier audio, l'artiste, le titre, le
+  corps du post et l'adresse de sa page
+
+#### Scénario : Morceau isolé
+
+- **QUAND** un consommateur demande `/post/:slug` au format `xspf`
+- **ALORS** une playlist d'un seul élément est servie, à l'image de ce que font les formats
+  `json` et `max`

--- a/openspec/changes/reparer-format-xspf/tasks.md
+++ b/openspec/changes/reparer-format-xspf/tasks.md
@@ -1,0 +1,33 @@
+## 1. Production du document XSPF sans PEAR
+
+- [ ] 1.1 Relever ce que produit `File_XSPF` aujourd'hui, d'après `listSuccess.xspf.php` : racine `playlist`, `title`, `date`, puis un `track` par morceau portant `location`, `creator`, `title`, `annotation` et `info`
+- [ ] 1.2 Réécrire `listSuccess.xspf.php` en produisant le XML directement, sans `require('File/XSPF.php')` ni `set_include_path()`. Conserver l'échappement des valeurs, que la bibliothèque assurait
+- [ ] 1.3 Conserver le comportement du titre : nom du contributeur si `contributor`, terme cherché si `q`, mention de l'ensemble sinon
+- [ ] 1.4 Retirer la manipulation de `error_reporting()` en tête de gabarit, qui n'existait que pour taire les avertissements de dépréciation de la bibliothèque PEAR
+- [ ] 1.5 Retirer le `// TODO : all this should not be in view` s'il n'a plus lieu d'être, ou le laisser s'il reste vrai — mais ne pas déplacer la logique hors de la vue à cette occasion : ce serait un autre changement
+
+## 2. Morceau isolé
+
+- [ ] 2.1 Créer `showSuccess.xspf.php`, servant une playlist d'un seul élément, à l'image de `showSuccess.json.php` et `showSuccess.max.php`
+- [ ] 2.2 Vérifier que le titre de cette playlist a du sens pour un morceau isolé
+
+## 3. Correction de l'exigence du corpus
+
+- [ ] 3.1 Confronter le scénario « Formats annoncés au visiteur » au code : `executeShow()` limite les formats à `json`, `executeList()` les passe tous les trois, et le drapeau `display` ne gouverne que les liens visibles du pied de page
+- [ ] 3.2 Vérifier qu'aucune autre exigence du corpus ne repose sur la même confusion entre `<link rel="alternate">` et liens visibles — relire `metadonnees-partage` en particulier
+
+## 4. Vérification manuelle
+
+> Toutes ces vérifications supposent le correctif déployé. Celles qui portent sur l'état
+> actuel — le 500, les formats annoncés — ont été menées contre la production avant
+> déploiement et sont consignées dans la proposition.
+
+- [ ] 4.1 Demander `/posts?format=xspf` et vérifier un code `200`, le type `application/xspf+xml`, et un corps non vide dont la racine est une playlist XSPF
+- [ ] 4.2 Demander `/posts?c=<contributeur>&format=xspf` et vérifier que le titre de la playlist nomme ce contributeur
+- [ ] 4.3 Demander `/posts?q=<terme>&format=xspf` et vérifier que le titre reprend le terme
+- [ ] 4.4 Demander `/post/:slug?format=xspf` et vérifier une playlist d'un seul élément, servie en `200`
+- [ ] 4.5 Ouvrir le document produit dans un lecteur qui lit le XSPF — VLC le fait — et vérifier que les morceaux se chargent depuis leur `location`
+- [ ] 4.6 Sur un morceau dont le titre ou le corps contient des guillemets, une esperluette ou un chevron, vérifier que le document reste bien formé. C'est ce que l'échappement de `File_XSPF` assurait, et le point le plus facile à casser en s'en passant
+- [ ] 4.7 Vérifier que `/posts?format=json`, `/posts?format=max` et `/posts/feed` répondent exactement comme avant — mêmes types de contenu, mêmes tailles à peu de chose près
+- [ ] 4.8 Sur une page de liste servie en HTML, vérifier que les trois `<link rel="alternate">` sont présents et que seuls `json` et `xspf` figurent dans les liens visibles du pied de page
+- [ ] 4.9 Sur une page de morceau servie en HTML, vérifier que `json` est le seul format annoncé, tout en restant accessible par `?format=xspf` et `?format=max`

--- a/openspec/changes/reparer-format-xspf/tasks.md
+++ b/openspec/changes/reparer-format-xspf/tasks.md
@@ -1,26 +1,69 @@
 ## 1. Production du document XSPF sans PEAR
 
-- [ ] 1.1 Relever ce que produit `File_XSPF` aujourd'hui, d'après `listSuccess.xspf.php` : racine `playlist`, `title`, `date`, puis un `track` par morceau portant `location`, `creator`, `title`, `annotation` et `info`
-- [ ] 1.2 Réécrire `listSuccess.xspf.php` en produisant le XML directement, sans `require('File/XSPF.php')` ni `set_include_path()`. Conserver l'échappement des valeurs, que la bibliothèque assurait
-- [ ] 1.3 Conserver le comportement du titre : nom du contributeur si `contributor`, terme cherché si `q`, mention de l'ensemble sinon
-- [ ] 1.4 Retirer la manipulation de `error_reporting()` en tête de gabarit, qui n'existait que pour taire les avertissements de dépréciation de la bibliothèque PEAR
-- [ ] 1.5 Retirer le `// TODO : all this should not be in view` s'il n'a plus lieu d'être, ou le laisser s'il reste vrai — mais ne pas déplacer la logique hors de la vue à cette occasion : ce serait un autre changement
+- [x] 1.1 Relever ce que produit `File_XSPF` aujourd'hui, d'après `listSuccess.xspf.php` : racine `playlist`, `title`, `date`, puis un `track` par morceau portant `location`, `creator`, `title`, `annotation` et `info`
+- [x] 1.2 Réécrire `listSuccess.xspf.php` en produisant le XML directement, sans `require('File/XSPF.php')` ni `set_include_path()`. Conserver l'échappement des valeurs, que la bibliothèque assurait
+      — le document est bâti avec `DOMDocument`, dont `createTextNode()` échappe. La
+      production est isolée dans un partiel, `_xspfPlaylist.php`, partagé avec le gabarit
+      de morceau isolé : écrire deux fois le même document, c'est le laisser diverger.
+- [x] 1.3 Conserver le comportement du titre : nom du contributeur si `contributor`, terme cherché si `q`, mention de l'ensemble sinon
+      — repris à l'identique, y compris le repli sur la valeur du paramètre quand la liste
+      filtrée par contributeur ne remonte aucun morceau.
+- [x] 1.4 Retirer la manipulation de `error_reporting()` en tête de gabarit, qui n'existait que pour taire les avertissements de dépréciation de la bibliothèque PEAR
+- [x] 1.5 Retirer le `// TODO : all this should not be in view` s'il n'a plus lieu d'être, ou le laisser s'il reste vrai — mais ne pas déplacer la logique hors de la vue à cette occasion : ce serait un autre changement
+      — retiré. Le gabarit de liste ne fait plus que calculer un titre et déléguer ; il n'y
+      a plus de logique à déplacer. Le sérialiser dans le modèle, comme `toJson()`, reste
+      possible et reste un autre sujet.
+- [x] 1.6 Passer par `$sf_data->getRaw('posts')` plutôt que par le décorateur d'échappement
+      — corrige un défaut latent de l'ancien gabarit, qui lisait `$posts` décoré : les
+      valeurs arrivaient déjà échappées en HTML, puis `File_XSPF` les échappait une
+      seconde fois. Le point ne s'observait pas, le format répondant 500 avant d'y
+      parvenir. `listSuccess.json.php` prend déjà cette précaution.
 
 ## 2. Morceau isolé
 
-- [ ] 2.1 Créer `showSuccess.xspf.php`, servant une playlist d'un seul élément, à l'image de `showSuccess.json.php` et `showSuccess.max.php`
-- [ ] 2.2 Vérifier que le titre de cette playlist a du sens pour un morceau isolé
+- [x] 2.1 Créer `showSuccess.xspf.php`, servant une playlist d'un seul élément, à l'image de `showSuccess.json.php` et `showSuccess.max.php`
+- [x] 2.2 Vérifier que le titre de cette playlist a du sens pour un morceau isolé
+      — `Musique Approximative : <artiste> — <titre>`. Un titre de liste
+      — « Tous les morceaux » — n'aurait rien voulu dire sur un morceau unique.
+- [x] 2.3 Vérifier que `?format=xspf` reste bien pris en compte sur une page de morceau,
+      malgré le `$formatsLimited` de `executeShow()`
+      — oui. `setFormats()` teste le paramètre contre la liste **complète** avant de poser
+      `sf_format` et le type de contenu ; `$formatsLimited` ne restreint que ce qui est
+      passé à la vue pour les liens annoncés. Le format reste donc accessible sans être
+      annoncé, ce qui est exactement ce que dit l'exigence corrigée.
 
 ## 3. Correction de l'exigence du corpus
 
-- [ ] 3.1 Confronter le scénario « Formats annoncés au visiteur » au code : `executeShow()` limite les formats à `json`, `executeList()` les passe tous les trois, et le drapeau `display` ne gouverne que les liens visibles du pied de page
-- [ ] 3.2 Vérifier qu'aucune autre exigence du corpus ne repose sur la même confusion entre `<link rel="alternate">` et liens visibles — relire `metadonnees-partage` en particulier
+- [x] 3.1 Confronter le scénario « Formats annoncés au visiteur » au code : `executeShow()` limite les formats à `json`, `executeList()` les passe tous les trois, et le drapeau `display` ne gouverne que les liens visibles du pied de page
+      — confirmé sur les deux canaux, dans le code et en production. Le scénario est
+      scindé en deux, un par type de page.
+- [x] 3.2 Vérifier qu'aucune autre exigence du corpus ne repose sur la même confusion entre `<link rel="alternate">` et liens visibles — relire `metadonnees-partage` en particulier
+      — aucune. Les cinq exigences de `metadonnees-partage` et les quatre de
+      `embarquement-oembed` portent sur le contenu des métadonnées, jamais sur leur
+      annonce.
+      — **Mais l'inverse apparaît** : les liens de découverte oEmbed
+      — `<link rel="alternate" type="application/json+oembed">` et sa variante XML, émis
+      par `layout.php` sur toutes les pages — **ne sont spécifiés nulle part**. C'est
+      pourtant le point d'entrée par lequel un consommateur trouve `/oembed`. Un trou du
+      corpus, distinct de celui que ce changement corrige, et hors de son périmètre.
 
 ## 4. Vérification manuelle
 
-> Toutes ces vérifications supposent le correctif déployé. Celles qui portent sur l'état
-> actuel — le 500, les formats annoncés — ont été menées contre la production avant
-> déploiement et sont consignées dans la proposition.
+> **Toutes ces vérifications supposent le correctif déployé, et aucune ne l'est.** Celles
+> qui portent sur l'état actuel — le 500, les formats annoncés — ont été menées contre la
+> production avant déploiement et sont consignées dans la proposition.
+>
+> Ce qui a été fait à la place, et qui ne les remplace pas : le partiel `_xspfPlaylist.php`
+> a été exercé hors Symfony, avec des bouchons pour la requête et `url_for()`. **Quatorze
+> contrôles, tous verts** — document bien formé, encodage déclaré, racine et espace de noms
+> XSPF, titre, date au format `xsd:dateTime`, nombre de morceaux, adresse absolue et
+> encodée du fichier audio, et surtout l'échappement : un morceau intitulé
+> `Rock <b>N</b> Roll "Live"` par `AC/DC & "friends"`, avec un corps contenant une balise
+> `script`, est restitué à l'identique sans casser le document ni produire de balise réelle.
+> C'est la tâche 4.6, et c'était le point le plus facile à casser en se passant de
+> `File_XSPF` — il reste néanmoins à revérifier sur une vraie page.
+>
+> `php -l` passe sur les trois gabarits. Le banc d'essai n'est pas versé au dépôt.
 
 - [ ] 4.1 Demander `/posts?format=xspf` et vérifier un code `200`, le type `application/xspf+xml`, et un corps non vide dont la racine est une playlist XSPF
 - [ ] 4.2 Demander `/posts?c=<contributeur>&format=xspf` et vérifier que le titre de la playlist nomme ce contributeur

--- a/src/apps/frontend/modules/post/templates/_xspfPlaylist.php
+++ b/src/apps/frontend/modules/post/templates/_xspfPlaylist.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Produit un document XSPF à partir d'une liste de morceaux.
+ *
+ * Partagé par `listSuccess.xspf.php` et `showSuccess.xspf.php`, un morceau isolé
+ * étant servi comme une playlist d'un seul élément — à l'image de ce que font
+ * déjà les formats json et max.
+ *
+ * Remplace la bibliothèque PEAR `File_XSPF`, absente de l'image Docker : son
+ * `require` échouait fatalement, et le format répondait 500 avec un corps vide.
+ * `DOMDocument` assure l'échappement que la bibliothèque assurait.
+ *
+ * @var array  $posts Morceaux bruts, hors décorateur d'échappement
+ * @var string $title Titre de la playlist
+ */
+
+$document = new DOMDocument('1.0', 'utf-8');
+$document->formatOutput = true;
+
+$playlist = $document->createElementNS('http://xspf.org/ns/0/', 'playlist');
+$playlist->setAttribute('version', '1');
+$document->appendChild($playlist);
+
+$playlist->appendChild($document->createElement('title'))
+  ->appendChild($document->createTextNode($title));
+
+// XSPF attend une date xsd:dateTime, et non un horodatage Unix.
+$playlist->appendChild($document->createElement('date'))
+  ->appendChild($document->createTextNode(date('c')));
+
+$trackList = $document->createElement('trackList');
+$playlist->appendChild($trackList);
+
+foreach ($posts as $post) {
+  $track = $document->createElement('track');
+  $trackList->appendChild($track);
+
+  $location = sprintf(
+    '%s%s/tracks/%s',
+    $sf_request->getUriPrefix(),
+    $sf_request->getRelativeUrlRoot(),
+    rawurlencode($post->track_filename)
+  );
+
+  // createTextNode échappe les valeurs : guillemets, esperluettes et chevrons
+  // d'un titre ou d'un corps de post ne peuvent pas casser le document.
+  $fields = array(
+    'location'   => $location,
+    'creator'    => $post->track_author,
+    'title'      => $post->track_title,
+    'annotation' => $post->body,
+    'info'       => url_for('@post_show?slug=' . $post->slug, true),
+  );
+
+  foreach ($fields as $name => $value) {
+    $track->appendChild($document->createElement($name))
+      ->appendChild($document->createTextNode((string) $value));
+  }
+}
+
+echo $document->saveXML();

--- a/src/apps/frontend/modules/post/templates/listSuccess.xspf.php
+++ b/src/apps/frontend/modules/post/templates/listSuccess.xspf.php
@@ -1,40 +1,17 @@
-<?php 
-// TODO : all this should not be in view
+<?php
+$posts = $sf_data->getRaw('posts');
 
-if (defined('E_DEPRECATED')) {
-	$errorLevel = error_reporting(E_ALL & ~E_DEPRECATED & ~E_NOTICE);
-} else {
-	$errorLevel = error_reporting(E_ALL & ~E_NOTICE);
-}
-
-set_include_path(get_include_path().':/usr/share/php');
-require('File/XSPF.php');
-
-$playlist = new File_XSPF();
-$playlist->setDate(time());
 if ($sf_request->getParameter('contributor')) {
-	if (count($posts)) {
-		$name = $posts[0]->getContributorDisplayName();
-	} else {
-		$name = $sf_request->getParameter('contributor');
-	}
-	$playlist->setTitle('Musique Approximative : Morceaux postés par ' . $name);
+  if (count($posts)) {
+    $name = $posts[0]->getContributorDisplayName();
+  } else {
+    $name = $sf_request->getParameter('contributor');
+  }
+  $title = 'Musique Approximative : Morceaux postés par ' . $name;
 } else if ($sf_request->getParameter('q')) {
-	$playlist->setTitle('Musique Approximative : Recherche sur le terme "'.$sf_request->getParameter('q').'"');
+  $title = 'Musique Approximative : Recherche sur le terme "' . $sf_request->getParameter('q') . '"';
 } else {
-	$playlist->setTitle('Musique Approximative : Tous les morceaux');
+  $title = 'Musique Approximative : Tous les morceaux';
 }
 
-foreach ($posts as $post) {
-	$track = new File_XSPF_Track();
-	$track->setCreator($post->track_author);
-	$track->setTitle($post->track_title);
-	$track->setAnnotation($post->body);
-	$track->setInfo(url_for('@post_show?slug='.$post->slug, true));
-	$location = new File_XSPF_Location();
-	$location->setUrl(sprintf('%s%s/tracks/%s', $sf_request->getUriPrefix(), $sf_request->getRelativeUrlRoot(), rawurlencode($post->track_filename)));
-	$track->addLocation($location);
-	$playlist->addTrack($track);
-}
-echo str_replace('<?xml version="1.0"?>', '<?xml version="1.0" encoding="utf-8"?>', $playlist->toString());
-error_reporting($errorLevel);
+include_partial('post/xspfPlaylist', array('posts' => $posts, 'title' => $title));

--- a/src/apps/frontend/modules/post/templates/showSuccess.xspf.php
+++ b/src/apps/frontend/modules/post/templates/showSuccess.xspf.php
@@ -1,0 +1,11 @@
+<?php
+// Un morceau isolé est servi comme une playlist d'un seul élément, à l'image des formats json et max.
+$post = $sf_data->getRaw('post');
+
+$title = sprintf(
+  'Musique Approximative : %s — %s',
+  $post->track_author,
+  $post->track_title
+);
+
+include_partial('post/xspfPlaylist', array('posts' => array($post), 'title' => $title));


### PR DESCRIPTION
Implémente `reparer-format-xspf`, sections 1 à 3. **11 tâches sur 20.** Les neuf restantes sont les vérifications manuelles, qui supposent le correctif déployé.

## Le constat

Relevé le 2 août 2026 contre `https://www.musiqueapproximative.net` :

| Requête | Statut | Type de contenu | Taille |
|---|---|---|---|
| `/posts` | 200 | `text/html` | 3 701 373 o |
| `/posts?format=json` | 200 | `application/json` | 7 947 865 o |
| `/posts?format=max` | 200 | `application/maxmsp+text` | 2 509 715 o |
| `/posts?format=xspf` | **500** | `text/html` | **0 o** |

`/post/:slug?format=xspf` échouait de même. Et la page de liste **annonce ce format**, en `<link rel="alternate" type="application/xspf+xml">` et dans ses liens visibles : le site proposait une adresse qui échoue.

## Deux causes distinctes

**Sur la liste** — `listSuccess.xspf.php` faisait :

```php
set_include_path(get_include_path().':/usr/share/php');
require('File/XSPF.php');
```

Le `Dockerfile` installe `bash curl gettext git make zip` et les extensions `opcache` et `pdo_mysql`. **Ni PEAR, ni `File_XSPF`.** Le `require` fatalait, d'où le 500 au corps vide. La dépendance existait sans doute sur l'hébergement d'origine ; elle n'a jamais été portée dans l'image.

**Sur un morceau isolé** — aucun gabarit `showSuccess.xspf.php`, alors que `json`, `max` et HTML ont chacun le leur.

## Le correctif

Le document est bâti avec `DOMDocument`, sans dépendance système. `File_XSPF` est sans version publiée depuis quinze ans, absente du `composer.json`, invisible de qui lit les dépendances déclarées, et son absence ne se manifeste que par un 500 muet. L'ajouter à l'image aurait reconduit le travers que ce dépôt collectionne.

La production est isolée dans un partiel, `_xspfPlaylist.php`, partagé par les deux gabarits — écrire deux fois le même document, c'est le laisser diverger. Un morceau isolé est servi comme une playlist d'un seul élément, à l'image de ce que font déjà `json` et `max`.

## Un défaut latent corrigé au passage

L'ancien gabarit lisait `$posts` **à travers le décorateur d'échappement** de Symfony : les valeurs arrivaient déjà échappées en HTML, puis `File_XSPF` les échappait une seconde fois. Le point ne s'observait pas, le format échouant avant d'y parvenir. `listSuccess.json.php` prenait déjà la précaution du `$sf_data->getRaw()` ; le gabarit XSPF ne la prenait pas.

## Une exigence fausse du corpus, corrigée

Le corpus affirmait que `json` et `xspf` sont annoncés au visiteur sur une page de morceau ou de liste, et que `max` ne l'est pas. Confronté au code et à la production :

- **une page de morceau n'annonce que `json`** — `executeShow()` construit un `$formatsLimited` délibéré ;
- **`max` est bien annoncé sur la liste**, en `<link rel="alternate">`. Le drapeau `display` ne gouverne que les liens visibles du pied de page.

La distinction entre les deux canaux n'existait pas dans l'exigence. Elle y entre, sous forme de deux scénarios distincts.

**Le corpus avait dérivé dès sa rédaction** : il a été écrit en lisant le code, sans le confronter à une instance qui tourne. C'est le mode de défaillance de ce dépôt, et le corpus n'y échappe pas — il l'attrape seulement plus vite.

À noter, l'inverse est apparu en relisant les capacités voisines : **les liens de découverte oEmbed ne sont spécifiés nulle part**, alors qu'ils sont le point d'entrée par lequel un consommateur trouve `/oembed`. Trou distinct, hors périmètre, consigné dans les tâches.

## Ce qui a été vérifié

`php -l` passe sur les trois gabarits. Le partiel a été exercé hors Symfony — le vendor n'est pas installé dans ce conteneur — avec des bouchons pour la requête et `url_for()`. **Quatorze contrôles, tous verts** : document bien formé, encodage déclaré, racine et espace de noms XSPF, titre, date au format `xsd:dateTime`, nombre de morceaux, adresse absolue et encodée du fichier audio.

Et surtout l'échappement, qui était le point le plus facile à casser en se passant de `File_XSPF` : un morceau intitulé `Rock <b>N</b> Roll "Live"` par `AC/DC & "friends"`, avec un corps contenant une balise `script`, est restitué à l'identique sans casser le document ni produire de balise réelle.

**Cela ne remplace pas les neuf vérifications manuelles**, qui restent ouvertes faute d'instance qui tourne ici. Le banc d'essai n'est pas versé au dépôt.

## Impact

`application/xspf+xml` est ce que le site annonce déjà ; il cessera simplement de mentir. Aucune route ne bouge, aucun autre format n'est touché.

`openspec validate --all` : **12 items, 0 échec.**