### PR TITLE
docs(openspec): consigne le ruleset main, et enterre l'hypothèse de l'approbation

### DIFF
--- a/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
+++ b/openspec/changes/appliquer-settings-yml-par-lapp/tasks.md
@@ -137,10 +137,38 @@
       d'ici — mais le blocage a cédé, ce qui suffit à valider le raisonnement. Reste à
       consigner la configuration retenue, pour qu'elle cesse d'être une connaissance
       orale : c'est l'objet de 3.4ter.
-- [ ] 3.4ter Consigner dans le dépôt la configuration du ruleset `main` — contextes requis,
+- [x] 3.4ter Consigner dans le dépôt la configuration du ruleset `main` — contextes requis,
       approbations exigées, liste de contournement. Sans quoi la prochaine dérive
       silencieuse mettra encore six mois à se voir. Un fichier de documentation, pas un
       fichier appliqué : `settings.yml` a montré ce que coûte la confusion entre les deux
+      — **relevée le 2 août 2026**, écran par écran. Elle cesse d'être une connaissance
+      orale :
+
+      | Réglage | Valeur |
+      |---|---|
+      | Nom du ruleset | `main` |
+      | Enforcement | Active |
+      | Contournement | Repository admin — Role — Always allow |
+      | Require a pull request before merging | activé |
+      | Required approvals | **0** |
+      | Dismiss stale approvals when new commits are pushed | activé, sans objet à 0 |
+      | Require review from specific teams | désactivé |
+      | Require review from Code Owners | désactivé |
+      | Do not require status checks on creation | désactivé |
+      | Contextes requis | `Trunk Check`, `Build et Push Docker`, `Validation du code` — tous GitHub Actions |
+      | Block force pushes | activé |
+
+      — Les règles **classiques** sont, elles, confirmées absentes : Réglages → Branches
+      affiche « Classic branch protections have not been configured ». C'est bien un
+      ruleset, et lui seul, qui protège `main`. Ce que l'app Settings n'aurait jamais pu
+      atteindre.
+      — Deux réglages restent hors du relevé, faute d'avoir été visibles : **« Require
+      branches to be up to date before merging »**, et l'existence éventuelle d'un
+      **second ruleset**, notamment au niveau de l'organisation. Ils sont suivis par
+      `reparer-fusion-automatique` 3.6quater.
+      — Ce tableau est un document de plus qui décrira sans contraindre. Il ne pilote
+      rien : les réglages GitHub font foi, et lui dérivera. Sa seule vertu est qu'un
+      écart futur devienne constatable — c'est déjà ce qui manquait le plus.
 - [x] 3.5 Décider du sort des sections `repository` et `labels`
       — **tranché par les faits : l'app est désinstallée.** Plus rien n'applique le
       fichier, quelle que soit sa section. `settings.yml` redevient ce qu'il était au

--- a/openspec/changes/reparer-fusion-automatique/tasks.md
+++ b/openspec/changes/reparer-fusion-automatique/tasks.md
@@ -145,13 +145,33 @@
 
       Ce qui reste vrai de 3.6 : `main` est protégée, et c'est bien un ruleset qui la
       gouverne. Ce qui tombe : l'idée que le blocage aurait cédé.
-- [ ] 3.6ter **Lire la section « Rules » du ruleset `main`.** C'est la seule information
+- [x] 3.6ter **Lire la section « Rules » du ruleset `main`.** C'est la seule information
       qui manque encore, et aucun outil accessible d'ici ne la donne — l'API des rulesets
       n'est pas exposée. Deux réglages suffisent : *Required approvals*, à mettre à **0**,
       et la liste des contextes requis, qui ne doit contenir que `Validation du code`,
       `Build et Push Docker` et `Trunk Check`. Tant qu'elle n'est pas lue, l'enquête
       raisonne sur une hypothèse au lieu d'un fait — c'est précisément l'erreur qui lui a
       coûté trois conclusions fausses
+      — **lue le 2 août 2026, et elle enterre l'explication qu'on tenait.** Les deux
+      réglages sont déjà dans l'état recommandé : *Required approvals* vaut **0**, et les
+      contextes requis sont exactement les trois qui existent. Voir
+      `appliquer-settings-yml-par-lapp` 3.4ter pour la composition complète.
+      — L'hypothèse de l'exigence d'approbation insatisfiable était **fausse**. C'est la
+      quatrième conclusion de cette enquête à tomber, et la leçon est toujours la même :
+      elle reposait sur une déduction — « il ne reste que ça » — au lieu d'une lecture.
+      Le raisonnement était solide, la prémisse manquait.
+      — Ce qui subsiste est un fait sans explication : **un ruleset entièrement
+      satisfaisable, une CI intégralement verte, et `mergeable_state: blocked`**, observé
+      quatre fois. Reporté en 3.6quater.
+- [ ] 3.6quater Élucider ce qui reste : le ruleset lu est satisfaisable de bout en bout, et
+      la pull request reste pourtant `blocked`. Deux pistes, aucune vérifiée :
+      **« Require branches to be up to date before merging »**, sous-option de
+      « Require status checks to pass » située juste au-dessus de la liste des contextes,
+      et qui bloquerait toute pull request dont la base a avancé — `main` a avancé sans
+      cesse pendant l'enquête ; ou bien **un second ruleset**, éventuellement défini au
+      niveau de l'organisation `constructions-incongrues`, qui apparaîtrait en lecture
+      seule dans la liste des rulesets du dépôt. Ne rien conclure avant d'avoir regardé
+      l'un et l'autre
 - [x] 3.7 Vérifier que le badge « Security Scan » du README repasse au vert, son résultat étant figé au 11 avril 2026
       — le run #202 de « Security Checks », déclenché à la main sur `main`, a abouti.
       Le badge affiche la conclusion du dernier run sur la branche par défaut.

--- a/openspec/changes/retirer-scan-trivy/tasks.md
+++ b/openspec/changes/retirer-scan-trivy/tasks.md
@@ -9,7 +9,11 @@
 - [x] 2.1 Sur la pull request de ce changement, vérifier qu'aucun check `Trivy Scan` n'apparaît plus
       — vérifié sur la PR #103 : le check a disparu de la liste, alors qu'il figurait sur
       toutes les pull requests depuis la #96.
-- [ ] 2.2 **Vérifier que `Trivy Scan` ne figure pas parmi les contextes requis du ruleset `main`**, et l'en retirer le cas échéant. Un contexte qui ne remonte jamais laisse la branche indéfiniment non fusionnable, sans message d'erreur — c'est le premier suspect pour expliquer que la fusion automatique n'ait jamais abouti. Les trois contextes qui subsistent sont `Validation du code`, `Build et Push Docker` et `Trunk Check`. À relever sous Réglages → Rules → Rulesets → `main`, et non sous Réglages → Branches
+- [x] 2.2 **Vérifier que `Trivy Scan` ne figure pas parmi les contextes requis du ruleset `main`**, et l'en retirer le cas échéant. Un contexte qui ne remonte jamais laisse la branche indéfiniment non fusionnable, sans message d'erreur — c'est le premier suspect pour expliquer que la fusion automatique n'ait jamais abouti. Les trois contextes qui subsistent sont `Validation du code`, `Build et Push Docker` et `Trunk Check`. À relever sous Réglages → Rules → Rulesets → `main`, et non sous Réglages → Branches
+      — **vérifié le 2 août 2026 : le piège n'a pas été retendu.** Les contextes requis du
+      ruleset sont exactement `Trunk Check`, `Build et Push Docker` et `Validation du
+      code`. Aucune trace de `Trivy Scan`, ni de `Build Docker`, le nom fantôme qui avait
+      bloqué la branche six mois durant.
 - [x] 2.3 Vérifier que le README et la page d'accueil de la documentation ne comportent plus de badge mort
       — vérifié sur `main` : zéro occurrence de `security.yml` dans `README.adoc` et dans
       `docs/modules/ROOT/pages/index.adoc`, et le fichier de workflow n'existe plus.


### PR DESCRIPTION
La section « Rules » du ruleset `main` a enfin été lue, écran par écran. Elle clôt deux tâches et **enterre l'explication qu'on tenait**.

## Ce que le ruleset déclare

| Réglage | Valeur |
|---|---|
| Nom | `main` |
| Enforcement | Active |
| Contournement | Repository admin — Role — Always allow |
| Require a pull request before merging | activé |
| **Required approvals** | **0** |
| Dismiss stale approvals when new commits are pushed | activé, sans objet à 0 |
| Require review from specific teams | désactivé |
| Require review from Code Owners | désactivé |
| Do not require status checks on creation | désactivé |
| Contextes requis | `Trunk Check`, `Build et Push Docker`, `Validation du code` |
| Block force pushes | activé |

Les règles **classiques** sont confirmées absentes : Réglages → Branches affiche « Classic branch protections have not been configured ». C'est bien un ruleset, et lui seul, qui protège `main` — ce que l'app Settings n'aurait jamais pu atteindre, et qui explique enfin son échec.

## L'hypothèse qui tombe

L'enquête concluait que l'exigence d'approbation était insatisfiable : un seul mainteneur, auteur de chaque pull request, et GitHub qui interdit d'approuver la sienne. **`Required approvals` vaut 0.** Il n'y a rien à satisfaire.

C'est la quatrième conclusion de cette enquête à tomber, et toujours pour la même raison : une déduction — « il ne reste que ça » — tenue pour un fait faute d'avoir regardé. Le raisonnement était solide à chaque fois ; c'est la prémisse qui manquait.

## Ce qui reste, et que je ne sais pas expliquer

Un ruleset **satisfaisable de bout en bout**, une CI **intégralement verte**, et `mergeable_state: blocked` — observé quatre fois cette nuit.

Deux pistes, aucune vérifiée, ouvertes en `3.6quater` :

- **« Require branches to be up to date before merging »**, sous-option de « Require status checks to pass » située juste au-dessus de la liste des contextes, hors du champ de la capture. Si elle est active, toute pull request dont la base a avancé devient `blocked` jusqu'à resynchronisation — et `main` a avancé sans cesse pendant l'enquête. C'est l'explication la plus économique ;
- **un second ruleset**, éventuellement défini au niveau de l'organisation `constructions-incongrues`, qui apparaîtrait en lecture seule dans la liste des rulesets du dépôt.

## Tâches closes

- **`retirer-scan-trivy` 2.2** — le piège du contexte fantôme n'a pas été retendu. Ni `Trivy Scan`, ni `Build Docker`, le nom qui avait bloqué la branche six mois durant.
- **`appliquer-settings-yml-par-lapp` 3.4ter** — la composition du ruleset cesse d'être une connaissance orale.
- **`reparer-fusion-automatique` 3.6ter** — la lecture est faite.

Le tableau ci-dessus est un document de plus qui décrira sans contraindre, et c'est écrit dans les tâches. Il ne pilote rien ; sa seule vertu est qu'un écart futur devienne constatable — ce qui est précisément ce qui manquait le plus à ce dépôt.

Documentation seule. Aucun fichier de `src/` n'est touché. `openspec validate --all` : 12 items, 0 échec.

---
_Generated by [Claude Code](https://claude.ai/code/session_019zTf3mfMqKTPeRfLkgurEW)_