### PR TITLE
fix(formats): passe baseUrl au partiel XSPF, et consigne la campagne de vérification

### DIFF
--- a/openspec/changes/generaliser-trigger-desastres/tasks.md
+++ b/openspec/changes/generaliser-trigger-desastres/tasks.md
@@ -67,22 +67,29 @@
 > désastre `X` se reconnaissent aux chemins `/desastres/X/javascript/*.js` et
 > `/desastres/X/stylesheets/*.css`, et aux options dans `window.DesastreOptions`.
 >
-> **Aucune n'a pu être menée : le correctif n'est pas déployé.** Ce changement ne modifie
-> que de la configuration et de la documentation — aucun code — et le mécanisme qu'il
-> généralise est déjà en service sur `tts_jinglist` depuis des mois. Ce qui a été contrôlé
-> ici, par script, tient en trois lignes : dix-neuf règles, dix-neuf déclencheurs, aucun
-> doublon, aucune collision avec un paramètre de l'application, et un tableau de
-> documentation qui correspond exactement à la configuration.
+> **Déployées et vérifiées le 2 août 2026, contre la production.** Les dix-neuf
+> déclencheurs forcent leur désastre, sans exception. Seule 4.7 reste ouverte : elle
+> suppose de désactiver une recette en configuration, ce qui n'a pas sa place sur un site
+> en ligne.
 >
-> Cela ne dit rien de ce qui compte : qu'un déclencheur force effectivement sa règle sur
-> une page servie. C'est l'objet de tout ce qui suit.
+> Deux contrôles avaient précédé le déploiement, et ils ne valaient que ce qu'ils
+> valaient : dix-neuf règles pour dix-neuf déclencheurs, sans doublon ni collision, et un
+> tableau de documentation conforme à la configuration. Ils ne disaient rien de ce qui
+> compte — qu'un déclencheur force effectivement sa règle sur une page servie. C'est
+> maintenant établi.
 
-- [ ] 4.1 Demander `/post/:slug?danse` sur un morceau dont le titre ne contient pas `danse`, et vérifier que le désastre est appliqué malgré la condition non satisfaite
-- [ ] 4.2 Demander `/post/:slug?kraftwerk` sur un morceau dont l'artiste n'est pas Kraftwerk — même attente
-- [ ] 4.3 Demander la même page **sans** paramètre, plusieurs fois, et vérifier que le désastre n'apparaît que selon sa probabilité. C'est le contrôle de non-régression qui compte : le forçage ne doit rien changer en son absence
-- [ ] 4.4 Demander `/post/:slug?quickos` un jour qui n'est ni le 24 ni le 25 décembre, et vérifier la redirection. C'est la vérification qui débloque la tâche 4.4 de `reparer-imports-desastres`, restée ouverte faute de pouvoir attendre décembre
-- [ ] 4.5 Demander `/post/:slug?bleu&noir` et vérifier que **les deux** désastres sont appliqués
-- [ ] 4.6 Demander un déclencheur avec une valeur — `?danse=1`, `?danse=true`, `?danse=nimportequoi` — et vérifier que les trois se comportent comme `?danse` seul
+- [x] 4.1 Demander `/post/:slug?danse` sur un morceau dont le titre ne contient pas `danse`, et vérifier que le désastre est appliqué malgré la condition non satisfaite
+- [x] 4.2 Demander `/post/:slug?kraftwerk` sur un morceau dont l'artiste n'est pas Kraftwerk — même attente
+- [x] 4.3 Demander la même page **sans** paramètre, plusieurs fois, et vérifier que le désastre n'apparaît que selon sa probabilité. C'est le contrôle de non-régression qui compte : le forçage ne doit rien changer en son absence
+      — vérifié sur `/post/patric-catani-le-split` : sans paramètre, seul `splitouine`
+      (`probability: 1`) apparaît, dix fois sur dix. Aucun des dix-huit autres désastres ne
+      s'invite. Le témoin historique tient aussi : `danse` continue de se déclencher sans
+      paramètre sur un morceau dont le titre le contient. **Aucune régression.**
+- [x] 4.4 Demander `/post/:slug?quickos` un jour qui n'est ni le 24 ni le 25 décembre, et vérifier la redirection. C'est la vérification qui débloque la tâche 4.4 de `reparer-imports-desastres`, restée ouverte faute de pouvoir attendre décembre
+- [x] 4.5 Demander `/post/:slug?bleu&noir` et vérifier que **les deux** désastres sont appliqués
+- [x] 4.6 Demander un déclencheur avec une valeur — `?danse=1`, `?danse=true`, `?danse=nimportequoi` — et vérifier que les trois se comportent comme `?danse` seul
 - [ ] 4.7 Marquer temporairement une recette `enabled: false`, forcer sa règle, et vérifier qu'elle n'est **pas** appliquée : le forçage porte sur la sélection de la règle, jamais sur l'activation d'une recette. Rétablir ensuite
-- [ ] 4.8 Parcourir les **dix-neuf** déclencheurs un à un et cocher cette tâche seulement quand les dix-neuf ont été constatés. Si l'un d'eux ne produit rien, l'écrire ici plutôt que cocher — c'est exactement le genre de panne silencieuse que ce changement existe pour rendre visible
-- [ ] 4.9 Demander `/posts/feed?danse`, `/post/:slug?format=json&danse` et `/oembed?url=...&danse`, et vérifier qu'aucun désastre n'est injecté : les recettes ne s'appliquent qu'aux réponses `text/html`
+      — **laissée ouverte à dessein.** Désactiver une recette en production pour observer le
+      résultat n'est pas un geste raisonnable. À faire sur une instance locale.
+- [x] 4.8 Parcourir les **dix-neuf** déclencheurs un à un et cocher cette tâche seulement quand les dix-neuf ont été constatés. Si l'un d'eux ne produit rien, l'écrire ici plutôt que cocher — c'est exactement le genre de panne silencieuse que ce changement existe pour rendre visible
+- [x] 4.9 Demander `/posts/feed?danse`, `/post/:slug?format=json&danse` et `/oembed?url=...&danse`, et vérifier qu'aucun désastre n'est injecté : les recettes ne s'appliquent qu'aux réponses `text/html`

--- a/openspec/changes/preciser-aleatoire-des-desastres/.openspec.yaml
+++ b/openspec/changes/preciser-aleatoire-des-desastres/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: musique-approximative
+created: 2026-08-02
+goal: Aligner l'exigence sur l'aléatoire des désastres avec le comportement
+  réel, que le cache de vues gèle par URL

--- a/openspec/changes/preciser-aleatoire-des-desastres/proposal.md
+++ b/openspec/changes/preciser-aleatoire-des-desastres/proposal.md
@@ -1,0 +1,112 @@
+## Why
+
+Le corpus affirme, sous « Requirement: Part d'aléatoire » :
+
+> Une règle SHALL pouvoir ne se déclencher qu'une fois sur plusieurs, afin que **deux
+> consultations de la même page ne produisent pas nécessairement le même effet**.
+
+C'est faux. Deux consultations de la même page produisent **toujours** le même effet, et ce
+pendant vingt-quatre heures.
+
+Mesuré le 2 août 2026 contre la production, sur `/post/eloi-soleil-mort`, dont le titre
+« Soleil Mort » satisfait la règle `postillons_mort` déclarée à `probability: 0.7` :
+
+| Requête | Déclenchements |
+|---|---|
+| URL nue, vingt fois | **0 / 20** |
+| URL variée par un paramètre inerte (`?cb=1`, `?cb=2`…), vingt fois | **11 / 20** |
+
+Obtenir zéro sur vingt à 0,7 a une probabilité de 3 × 10⁻¹¹. Ce n'est pas du hasard : le
+tirage est **figé par URL**.
+
+Ni le navigateur ni Cloudflare n'y sont pour quelque chose — les en-têtes de réponse
+annoncent `no-store, no-cache, must-revalidate` et `cf-cache-status: DYNAMIC`. C'est le
+cache de vues de Symfony, déclaré sans réserve dans `src/apps/frontend/config/cache.yml` :
+
+```yaml
+default:
+  enabled:     true
+  with_layout: true
+  lifetime:    86400
+```
+
+Toutes les actions, avec le gabarit d'habillage, pour **86 400 secondes**. Un désastre
+tiré une fois est donc servi à tous les visiteurs de cette URL pendant vingt-quatre heures,
+puis retiré au hasard suivant.
+
+**Un désastre à `probability: 0.7` ne se déclenche pas sur 70 % des visites, mais sur 70 %
+des remplissages de cache.**
+
+Ce n'est pas nécessairement un défaut. C'en est un pour le corpus, qui décrit autre chose
+que ce qui se passe — et ce dépôt a déjà payé neuf fois le prix d'un document qui décrit
+sans correspondre.
+
+## What Changes
+
+- L'exigence « Part d'aléatoire » est réécrite pour décrire ce qui a lieu : le tirage est
+  fait au rendu, puis figé pour la durée du cache, et il porte sur une URL et non sur une
+  visite.
+- Une exigence est ajoutée sur la granularité du hasard, pour que la propriété soit
+  énoncée plutôt que subie : ce qui varie, c'est la page et le moment, pas le visiteur.
+- **Aucun changement de comportement.** Ce changement documente ; il ne touche ni au
+  cache, ni au moteur de règles, ni à une seule recette.
+
+### L'arbitrage : décrire, ou corriger
+
+Deux voies s'offraient, et la seconde est écartée pour ce changement-ci.
+
+**Corriger** supposerait de soustraire les désastres au cache — cache par fragment,
+exclusion des actions concernées, ou injection côté client. Chacune de ces pistes coûte
+cher sur un socle Symfony 1.5, et l'une d'elles au moins — désactiver le cache sur
+`post/show` et `post/list` — dégraderait un site dont c'est l'essentiel du trafic. Le
+rapport bénéfice/risque n'est pas favorable pour rétablir un aléa par visiteur dont
+personne n'a établi qu'il était voulu.
+
+**Décrire** coûte une exigence réécrite et rend la propriété visible. Si le comportement
+figé déplaît, la discussion pourra s'ouvrir sur une base exacte plutôt que sur une
+exigence qui prétend le contraire.
+
+Le choix retenu est de décrire. **Il est réversible : rien n'empêche un changement
+ultérieur de modifier le comportement**, et il partira alors d'un corpus qui dit vrai.
+
+### Approche
+
+La contrainte du socle qui oriente ce choix : sur Symfony 1.5, le cache d'action avec
+gabarit court-circuite l'action entière. `apply_desastre()` n'est donc pas rappelée sur un
+succès de cache, et le tirage ne peut pas être rejoué sans repenser l'endroit où les
+désastres sont appliqués. Ce n'est pas un réglage, c'est une décision d'architecture.
+
+L'ordre exact entre l'écriture du cache et le filtre d'injection `sfDesastreFilter` n'a pas
+pu être établi de l'extérieur, et ce changement ne l'affirme pas. Ce qui est mesuré, et qui
+suffit à l'exigence, c'est que le résultat servi est identique d'une requête à l'autre.
+
+## Hors périmètre
+
+- **Toute modification du cache** — `cache.yml`, `lifetime`, exclusion d'actions, cache par
+  fragment. C'est l'objet d'un éventuel changement suivant, et il devra peser le coût sur
+  la charge du site.
+- Le moteur de règles, les probabilités déclarées, les recettes, les déclencheurs.
+- La question de savoir si l'aléa par visiteur est souhaitable. Ce changement ne la tranche
+  pas ; il la rend posable.
+- Les autres capacités, dont aucune ne décrit un comportement dépendant du cache. Vérifié
+  au passage.
+
+## Capacités
+
+### Nouvelles capacités
+
+Aucune.
+
+### Capacités modifiées
+
+- `desastres` — l'exigence « Part d'aléatoire » est corrigée, et complétée d'une exigence
+  sur la granularité du tirage.
+
+## Impact
+
+- `openspec/specs/desastres/spec.md` après synchronisation.
+- **Aucun fichier de `src/` n'est touché.** Contrat public inchangé, comportement inchangé.
+- Ce que le lecteur du corpus y gagne : il cesse d'attendre des désastres un aléa par
+  visiteur, et sait que pour observer une règle probabiliste il lui faut faire varier
+  l'URL — ce qui est exactement le geste que la campagne de vérification a dû inventer
+  faute de le trouver écrit.

--- a/openspec/changes/preciser-aleatoire-des-desastres/specs/desastres/spec.md
+++ b/openspec/changes/preciser-aleatoire-des-desastres/specs/desastres/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Part d'aléatoire
+
+Une règle SHALL pouvoir ne se déclencher qu'une fois sur plusieurs. Le tirage SHALL être
+fait au moment où la page est produite, et son résultat SHALL valoir pour toutes les
+consultations servies depuis la même représentation mise en cache.
+
+#### Scénario : Règle probabiliste
+
+- **QUAND** une règle déclare une probabilité inférieure à 1
+- **ALORS** elle ne se déclenche qu'une partie du temps, pour un même contexte
+- **ET** la proportion observée sur un grand nombre de productions de page tend vers la
+  probabilité déclarée
+
+#### Scénario : Règle certaine
+
+- **QUAND** une règle déclare une probabilité de 1
+- **ALORS** elle se déclenche à chaque fois que son expression est satisfaite
+
+#### Scénario : Consultations successives d'une même adresse
+
+- **QUAND** une même adresse est demandée plusieurs fois pendant la durée de vie du cache
+- **ALORS** toutes les réponses portent le même résultat de tirage
+- **ET** deux visiteurs différents voient donc le même effet
+
+#### Scénario : Observation d'une règle probabiliste
+
+- **QUAND** on cherche à constater qu'une règle probabiliste se déclenche bien
+- **ALORS** recharger la même adresse ne suffit pas
+- **ET** il faut soit forcer la règle par son déclencheur, soit faire varier l'adresse pour
+  provoquer autant de productions de page que de tirages souhaités
+
+### Requirement: Granularité du tirage
+
+Le hasard des désastres SHALL porter sur l'adresse demandée et sur le moment, et non sur le
+visiteur.
+
+#### Scénario : Deux adresses différentes
+
+- **QUAND** deux adresses distinctes satisfont chacune une même règle probabiliste
+- **ALORS** leurs tirages sont indépendants
+
+#### Scénario : Une même adresse dans le temps
+
+- **QUAND** la représentation en cache d'une adresse expire et que la page est produite à
+  nouveau
+- **ALORS** un nouveau tirage a lieu
+- **ET** l'effet servi peut différer de celui de la période précédente
+
+#### Scénario : Deux visiteurs sur la même adresse
+
+- **QUAND** deux visiteurs demandent la même adresse pendant la même période de cache
+- **ALORS** ils voient le même effet, quel que soit leur navigateur ou leur session

--- a/openspec/changes/preciser-aleatoire-des-desastres/tasks.md
+++ b/openspec/changes/preciser-aleatoire-des-desastres/tasks.md
@@ -1,0 +1,35 @@
+## 1. Correction de l'exigence
+
+- [x] 1.1 Réécrire « Requirement: Part d'aléatoire » pour décrire le tirage tel qu'il a lieu : au moment de la production de la page, puis figé pour la durée du cache
+- [x] 1.2 Retirer l'affirmation « deux consultations de la même page ne produisent pas nécessairement le même effet », que la mesure contredit
+- [x] 1.3 Ajouter un scénario disant comment observer une règle probabiliste — forcer par le déclencheur, ou faire varier l'adresse. C'est le geste que la campagne de vérification a dû inventer faute de le trouver écrit
+- [x] 1.4 Ajouter une exigence « Granularité du tirage » : le hasard porte sur l'adresse et sur le moment, jamais sur le visiteur
+
+## 2. Contrôle du reste du corpus
+
+- [x] 2.1 Vérifier qu'aucune autre exigence ne suppose un aléa par visiteur ou par consultation
+      — aucune. Les cinq autres capacités décrivent des réponses déterministes ; seule
+      `desastres` introduit du hasard.
+- [ ] 2.2 Relire les quatre scénarios de « Déclenchement conditionnel » à la lumière du cache — ils portent sur l'évaluation d'une règle, non sur sa fréquence, et devraient rester valides. À confirmer plutôt qu'à supposer
+
+## 3. Vérification manuelle
+
+> Ce changement ne modifie aucun comportement : il n'y a rien à vérifier sur le site. Les
+> mesures qui fondent l'exigence ont été faites **avant** sa rédaction, et sont reproduites
+> ci-dessous pour qu'un lecteur puisse les refaire.
+
+- [x] 3.1 Mesurer une règle probabiliste sur une URL nue
+      — `/post/eloi-soleil-mort`, règle `postillons_mort` à `probability: 0.7` :
+      **0 déclenchement sur 20**. À 0,7, probabilité de 3 × 10⁻¹¹.
+- [x] 3.2 Mesurer la même règle en faisant varier l'adresse
+      — même page avec un paramètre inerte, `?cb=1` à `?cb=20` : **11 sur 20**, conforme à
+      0,7. C'est le tirage qui est figé, pas la règle qui est cassée.
+- [x] 3.3 Écarter le navigateur et l'intermédiaire de diffusion comme causes
+      — en-têtes de la réponse : `cache-control: no-store, no-cache, must-revalidate`,
+      `expires` daté de 1981, `cf-cache-status: DYNAMIC`. Rien n'est mis en cache en aval :
+      c'est bien le cache de vues de l'application.
+- [x] 3.4 Relever la configuration du cache
+      — `src/apps/frontend/config/cache.yml` : `enabled: true`, `with_layout: true`,
+      `lifetime: 86400`. Toutes les actions, avec habillage, pendant vingt-quatre heures.
+- [ ] 3.5 Établir l'ordre exact entre l'écriture du cache et le filtre `sfDesastreFilter`, qui injecte après le rendu. Le résultat mesuré ne dépend pas de cette réponse, mais elle conditionne toute tentative future de rétablir un tirage par visiteur — et elle ne s'obtient pas de l'extérieur
+- [ ] 3.6 Décider si le comportement doit changer. Ce changement ne le tranche pas : il rend la question posable sur une base exacte. Toute correction passerait par le cache — exclusion d'actions, cache par fragment, ou injection côté client — et devra peser le coût sur la charge d'un site dont `post/show` et `post/list` font l'essentiel du trafic

--- a/openspec/changes/reparer-format-xspf/tasks.md
+++ b/openspec/changes/reparer-format-xspf/tasks.md
@@ -49,22 +49,35 @@
 
 ## 4. Vérification manuelle
 
-> **Toutes ces vérifications supposent le correctif déployé, et aucune ne l'est.** Celles
-> qui portent sur l'état actuel — le 500, les formats annoncés — ont été menées contre la
-> production avant déploiement et sont consignées dans la proposition.
+> **Une première correction a été déployée et n'a pas fonctionné.** Le détail est en 4.0 :
+> un partiel symfony 1 n'hérite d'aucune variable de son appelant, et le mien attendait
+> `$sf_request`. Corrigé, mais **non redéployé** à l'heure où ces lignes sont écrites.
 >
-> Ce qui a été fait à la place, et qui ne les remplace pas : le partiel `_xspfPlaylist.php`
-> a été exercé hors Symfony, avec des bouchons pour la requête et `url_for()`. **Quatorze
-> contrôles, tous verts** — document bien formé, encodage déclaré, racine et espace de noms
-> XSPF, titre, date au format `xsd:dateTime`, nombre de morceaux, adresse absolue et
-> encodée du fichier audio, et surtout l'échappement : un morceau intitulé
-> `Rock <b>N</b> Roll "Live"` par `AC/DC & "friends"`, avec un corps contenant une balise
-> `script`, est restitué à l'identique sans casser le document ni produire de balise réelle.
-> C'est la tâche 4.6, et c'était le point le plus facile à casser en se passant de
-> `File_XSPF` — il reste néanmoins à revérifier sur une vraie page.
->
-> `php -l` passe sur les trois gabarits. Le banc d'essai n'est pas versé au dépôt.
+> Toutes les cases ci-dessous restent donc ouvertes, et le resteront jusqu'au prochain
+> `make deploy`. Ce qui a été fait à la place — un banc d'essai reproduisant cette fois
+> l'isolement du partiel, sept assertions vertes, et l'échec attendu sans la variable — ne
+> les remplace pas. Le premier banc était vert lui aussi.
 
+- [x] 4.0 **Constater que la première correction ne fonctionnait pas, et trouver pourquoi**
+      — relevé après déploiement : `?format=xspf` répondait toujours `500` avec un corps
+      vide, sur les deux routes. Le déploiement était pourtant bien passé — `?kraftwerk`
+      forçait son désastre, donc la PR #112, postérieure à celle-ci, était en ligne.
+      — **Cause : un partiel symfony 1 est hermétique.** `get_partial()` n'appelle que
+      `setPartialVars()` : le porteur d'attributs du partiel ne contient que les variables
+      qu'on lui passe. Ni `$sf_request`, ni `$sf_data`, ni `$sf_context`. Le partiel
+      appelait `$sf_request->getUriPrefix()`, soit une méthode sur `null`, soit une erreur
+      fatale, soit un 500 au corps vide.
+      — **Le banc d'essai n'a pas pu l'attraper, et c'est instructif.** Il déclarait
+      `$sf_request` comme variable locale avant d'inclure le gabarit : il validait la
+      logique du gabarit, jamais la portée que le framework lui accorde. Un banc qui
+      fournit ce que l'appelant réel ne fournit pas ne teste que lui-même.
+      — Corrigé en passant `baseUrl`, calculé par l'appelant. Le partiel a besoin d'un
+      préfixe, pas d'un objet requête, et son contrat en devient explicite.
+      — Deux contrôles refaits, cette fois en reproduisant l'isolement : sept assertions
+      vertes avec `baseUrl`, et l'échec attendu — « Undefined variable $baseUrl » — sans.
+      — `DOMDocument` a été écarté comme cause par mesure, non par supposition :
+      `/oembed?format=xml` répond `200` en production et construit sa réponse avec
+      `SimpleXMLElement`, donc l'extension XML est bien présente dans l'image.
 - [ ] 4.1 Demander `/posts?format=xspf` et vérifier un code `200`, le type `application/xspf+xml`, et un corps non vide dont la racine est une playlist XSPF
 - [ ] 4.2 Demander `/posts?c=<contributeur>&format=xspf` et vérifier que le titre de la playlist nomme ce contributeur
 - [ ] 4.3 Demander `/posts?q=<terme>&format=xspf` et vérifier que le titre reprend le terme

--- a/openspec/changes/reparer-format-xspf/tasks.md
+++ b/openspec/changes/reparer-format-xspf/tasks.md
@@ -53,8 +53,10 @@
 > un partiel symfony 1 n'hérite d'aucune variable de son appelant, et le mien attendait
 > `$sf_request`. Corrigé, mais **non redéployé** à l'heure où ces lignes sont écrites.
 >
-> Toutes les cases ci-dessous restent donc ouvertes, et le resteront jusqu'au prochain
-> `make deploy`. Ce qui a été fait à la place — un banc d'essai reproduisant cette fois
+> Toutes les cases ci-dessous restent donc ouvertes, et le resteront jusqu'à la prochaine
+> mise en ligne. **Elle est automatique** : Plesk tire `main` à chaque poussée, il n'y a pas
+> de geste de déploiement — le `make deploy` par rsync du Makefile est déprécié. Fusionner
+> cette pull request, c'est donc mettre en production. Ce qui a été fait à la place — un banc d'essai reproduisant cette fois
 > l'isolement du partiel, sept assertions vertes, et l'échec attendu sans la variable — ne
 > les remplace pas. Le premier banc était vert lui aussi.
 

--- a/openspec/changes/reparer-fusion-automatique/tasks.md
+++ b/openspec/changes/reparer-fusion-automatique/tasks.md
@@ -172,6 +172,14 @@
       niveau de l'organisation `constructions-incongrues`, qui apparaîtrait en lecture
       seule dans la liste des rulesets du dépôt. Ne rien conclure avant d'avoir regardé
       l'un et l'autre
+      — **la première piste est écartée par mesure**, le 2 août. La PR #115 est restée
+      `blocked` avec sa CI verte alors que sa base était `main` à jour, au commit près :
+      elle ne pouvait donc pas être en retard sur quoi que ce soit. « Require branches to
+      be up to date before merging » ne peut pas expliquer le blocage.
+      — Reste la seconde, et elle seule parmi celles nommées. Un coup d'œil à la liste
+      `Réglages → Rules → Rulesets` suffit : s'il n'y figure qu'une ligne, il faudra
+      chercher ailleurs — et se garder de conclure « il ne reste que ça », erreur déjà
+      commise quatre fois dans cette enquête.
 - [x] 3.7 Vérifier que le badge « Security Scan » du README repasse au vert, son résultat étant figé au 11 avril 2026
       — le run #202 de « Security Checks », déclenché à la main sur `main`, a abouti.
       Le badge affiche la conclusion du dernier run sur la branche par défaut.

--- a/openspec/changes/reparer-imports-desastres/tasks.md
+++ b/openspec/changes/reparer-imports-desastres/tasks.md
@@ -52,33 +52,55 @@
 
 ## 4. Vérification manuelle
 
-> **Les vérifications qui portent sur le correctif restent ouvertes : il n'est pas
-> déployé.** La production sert encore le code fautif, et le conteneur d'implémentation n'a
-> ni instance qui tourne, ni base de données, ni vendor Symfony. Ces cases se cocheront
-> après `make deploy`, pas avant.
+> **Déployé et vérifié le 2 août 2026.** La campagne a été menée contre la production.
+> Une seule case reste ouverte, 4.2, qui suppose d'introduire une faute volontaire dans un
+> chemin d'import — geste qui n'a pas sa place sur un site en ligne.
 >
-> **Ce qui a en revanche pu être établi contre la production**, et qui lève les deux
-> inconnues qui pesaient sur ce changement : les morceaux nécessaires existent, et le bug
-> est constaté en direct. Voir 4.8.
+> Le bug avait été constaté en direct **avant** correction, avec témoin : voir 4.8. C'est
+> ce qui donne son poids à la campagne d'après-déploiement — on sait ce qui a changé, et
+> pas seulement ce qui marche.
 >
-> Le désastre `quickos` reste par ailleurs invérifiable avant décembre : sa condition porte
-> sur `context.date.month == '12'`, et rien ne permet aujourd'hui de forcer une règle —
-> c'est précisément ce qu'apporte `generaliser-trigger-desastres`. Son échéance est réelle.
+> L'échéance de décembre est levée : `generaliser-trigger-desastres` a abouti dans la même
+> nuit, et `?quickos` remplace l'attente de Noël.
 
-- [ ] 4.1 Sur une page de morceau quelconque, ouvrir la console du navigateur et vérifier qu'**aucun** avertissement de désastre n'apparaît — les quatorze imports se résolvent désormais
+- [x] 4.1 Sur une page de morceau quelconque, ouvrir la console du navigateur et vérifier qu'**aucun** avertissement de désastre n'apparaît — les quatorze imports se résolvent désormais
+      — zéro occurrence de `console.warn` ou d'un avertissement d'import dans le HTML servi.
 - [ ] 4.2 Introduire volontairement une faute dans un chemin d'import, recharger une page de morceau, et vérifier que la console nomme le chemin fautif **et** que la page reste servie normalement. Rétablir le chemin ensuite
-- [ ] 4.3 Trouver un morceau dont l'artiste contient `catani`, demander `/post/:slug`, et vérifier dans le HTML servi que les ressources du désastre `splitouine` sont injectées avant `</head>`. La règle déclare `probability: 1` : elle doit se déclencher à chaque fois, sans exception. C'est la preuve que `regles/splitouine.yml` et `recettes/splitouine.yml` se chargent enfin. Si aucun morceau ne correspond, le noter ici plutôt que cocher
+      — **non menée, et laissée ouverte à dessein.** Casser volontairement la configuration
+      d'un site en production pour observer un avertissement n'est pas un geste raisonnable.
+      À faire sur une instance locale. La logique a été exercée hors Symfony au moment de
+      l'implémentation, ce qui ne vaut pas constat.
+- [x] 4.3 Trouver un morceau dont l'artiste contient `catani`, demander `/post/:slug`, et vérifier dans le HTML servi que les ressources du désastre `splitouine` sont injectées avant `</head>`. La règle déclare `probability: 1` : elle doit se déclencher à chaque fois, sans exception. C'est la preuve que `regles/splitouine.yml` et `recettes/splitouine.yml` se chargent enfin. Si aucun morceau ne correspond, le noter ici plutôt que cocher
       — **le morceau existe** : `/post/patric-catani-le-split`. En production, avant
       déploiement, **aucun désastre n'y est injecté** — ce qui confirme le bug (voir 4.8).
-      La case se coche quand `desastres/splitouine` apparaîtra sur cette page.
-- [ ] 4.4 **Bloquée jusqu'en décembre 2026.** Vérifier qu'un morceau demandé un 24 ou un 25 décembre redirige vers `quickoschantenoel.musiqueapproximative.net` au bout de trois secondes, une fois sur deux. À rouvrir à cette date, ou plus tôt si `generaliser-trigger-desastres` aboutit d'ici là
-- [ ] 4.5 Chercher un morceau dont le titre est exactement `Spooky Mix`, demander `/post/:slug`, et vérifier la redirection vers `sos.musiqueapproximative.net` — `probability: 1` là aussi. Si ce morceau n'existe pas au catalogue, le noter : la règle serait alors inerte pour une seconde raison, indépendante de celle que ce changement corrige
+      — **vérifié après déploiement : `desastres/splitouine` est injecté**, à chaque
+      requête, avec ou sans paramètre. La règle `catani` déclare `probability: 1` et se
+      déclenche sans exception. `regles/splitouine.yml` et `recettes/splitouine.yml` se
+      chargent enfin — sept mois après avoir été écrits.
+- [x] 4.4 **Bloquée jusqu'en décembre 2026.** Vérifier qu'un morceau demandé un 24 ou un 25 décembre redirige vers `quickoschantenoel.musiqueapproximative.net` au bout de trois secondes, une fois sur deux. À rouvrir à cette date, ou plus tôt si `generaliser-trigger-desastres` aboutit d'ici là
+      — **débloquée, et vérifiée le 2 août.** `generaliser-trigger-desastres` a abouti dans
+      la même nuit : `?quickos` et `?quickos_noel` forcent l'un et l'autre le désastre
+      `redirect`, un 2 août. Les deux règles sont bien chargées et fonctionnelles. Ce qui
+      reste invérifiable avant Noël est leur *condition* de date, pas leur existence — et
+      c'était l'objet de cette tâche.
+- [x] 4.5 Chercher un morceau dont le titre est exactement `Spooky Mix`, demander `/post/:slug`, et vérifier la redirection vers `sos.musiqueapproximative.net` — `probability: 1` là aussi. Si ce morceau n'existe pas au catalogue, le noter : la règle serait alors inerte pour une seconde raison, indépendante de celle que ce changement corrige
+      — **vérifié le 2 août : `?spooky` force bien le désastre `redirect`.** La règle est
+      chargée, ce qui était l'objet de cette tâche.
       — **le morceau existe** : `/post/dumbshitthatjakazidmade-spooky-mix`, dont le titre
       est exactement `Spooky Mix`. La condition `query.title == 'Spooky Mix'` porte donc
       bien sur quelque chose. En production, aucun désastre n'y est injecté. La seconde
       raison redoutée est écartée : la règle n'est inerte que par l'import cassé.
-- [ ] 4.6 Sur un morceau dont le titre contient `mort`, `death` ou `dead`, recharger une dizaine de fois et constater que le désastre `postillons_mort` ne se déclenche plus systématiquement. La vérification est statistique et donc faible : elle ne distingue pas 0,7 de 0,91 sur dix tirages. Elle ne vaut que comme contrôle grossier de non-régression
-- [ ] 4.7 Demander `/posts/feed`, `/post/:slug?format=json` et `/oembed?url=...`, et vérifier qu'aucun `<script>` de désastre n'apparaît dans ces réponses
+- [x] 4.6 Sur un morceau dont le titre contient `mort`, `death` ou `dead`, recharger une dizaine de fois et constater que le désastre `postillons_mort` ne se déclenche plus systématiquement. La vérification est statistique et donc faible : elle ne distingue pas 0,7 de 0,91 sur dix tirages. Elle ne vaut que comme contrôle grossier de non-régression
+      — **menée, et elle a révélé bien autre chose.** Sur `/post/eloi-soleil-mort`, vingt
+      requêtes à l'URL nue : **zéro déclenchement**. À p = 0,7, c'est une probabilité de
+      3 × 10⁻¹¹ — pas de la malchance.
+      — Les mêmes vingt requêtes avec un paramètre inerte qui fait varier l'URL — `?cb=1`,
+      `?cb=2`… — donnent **11 déclenchements sur 20**, conforme à 0,7. La correction du
+      doublon est donc bien en place ; c'est le **cache** qui gèle le tirage par URL.
+      Détaillé en 4.9.
+- [x] 4.7 Demander `/posts/feed`, `/post/:slug?format=json` et `/oembed?url=...`, et vérifier qu'aucun `<script>` de désastre n'apparaît dans ces réponses
+      — **vérifié après déploiement** : zéro occurrence sur `/posts/feed`, `?format=json`
+      et `?format=max`, y compris en y ajoutant un déclencheur.
       — **état de référence relevé avant déploiement** : zéro occurrence de `desastres/`
       ou `DesastreOptions` sur `/posts/feed` (`application/rss+xml`),
       `?format=json` (`application/json`), `?format=max` (`application/maxmsp+text`) et
@@ -100,3 +122,21 @@
       par un plugin éteint ou un cache, mais bien par les imports non résolus. Les trois
       règles déclarent `probability: 1` : aucune n'est soumise au hasard, et le résultat
       est reproductible à chaque requête.
+- [x] 4.9 **Trouvaille de la campagne : le cache gèle l'aléatoire.** Hors périmètre de ce
+      changement, consignée ici parce que c'est ici qu'elle est apparue
+      — un désastre à `probability: 0.7` ne se déclenche pas sur 70 % des visites, mais sur
+      70 % des **remplissages de cache**. Une fois la page rendue et mise en cache, le
+      tirage est figé jusqu'à expiration : tous les visiteurs voient le même résultat.
+      — Mesures : `/post/eloi-soleil-mort` sans paramètre, 0/20 ; avec un paramètre inerte
+      faisant varier l'URL, 11/20. Le cache n'est ni celui du navigateur ni celui de
+      Cloudflare — les en-têtes disent `no-store, no-cache, must-revalidate` et
+      `cf-cache-status: DYNAMIC`. C'est le cache de vues de Symfony, `frontend_cache.php`,
+      clé par URI.
+      — **Cela contredit une exigence du corpus.** « Requirement: Part d'aléatoire » énonce
+      qu'« une règle SHALL pouvoir ne se déclencher qu'une fois sur plusieurs, afin que deux
+      consultations de la même page ne produisent pas nécessairement le même effet ». Deux
+      consultations de la même page produisent en réalité **toujours** le même effet, tant
+      que le cache tient.
+      — Ce que cela vaut : les désastres probabilistes varient d'une page à l'autre et dans
+      le temps, pas d'un visiteur à l'autre. C'est peut-être ce qu'on veut ; ce n'est pas ce
+      que le corpus décrit. Mérite son propre changement.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -6,7 +6,10 @@ context: |
 
   Stack : Symfony 1.5 (legacy, fin de vie) + Doctrine 1.3, PHP 7.4, MySQL,
   templates PHP. jQuery côté client, lecteur audio jPlayer.
-  Dev sous Docker Compose (nginx :8080, PHP :8001) ; déploiement par rsync (`make deploy`).
+  Dev sous Docker Compose (nginx :8080, PHP :8001). Déploiement **automatique** :
+  Plesk tire `main` à chaque poussée, il n'y a pas de geste de mise en ligne. Une
+  fusion sur `main` est donc une mise en production, et le `make deploy` par rsync
+  que décrit encore le Makefile est déprécié.
 
   Deux applications : `src/apps/frontend` (public) et `src/apps/admin`.
   Modèle central : `Post` (track_author, track_title, track_filename, body en Markdown,

--- a/src/apps/frontend/modules/post/templates/_xspfPlaylist.php
+++ b/src/apps/frontend/modules/post/templates/_xspfPlaylist.php
@@ -10,8 +10,15 @@
  * `require` échouait fatalement, et le format répondait 500 avec un corps vide.
  * `DOMDocument` assure l'échappement que la bibliothèque assurait.
  *
- * @var array  $posts Morceaux bruts, hors décorateur d'échappement
- * @var string $title Titre de la playlist
+ * Un partiel symfony 1 est hermétique : son porteur d'attributs ne contient que
+ * les variables qu'on lui passe. Ni `$sf_request`, ni `$sf_data`, ni `$sf_context`
+ * n'y sont disponibles — voir `get_partial()`, qui n'appelle que `setPartialVars()`.
+ * D'où `$baseUrl`, calculé par l'appelant : le partiel a besoin d'un préfixe, pas
+ * d'un objet requête.
+ *
+ * @var array  $posts   Morceaux bruts, hors décorateur d'échappement
+ * @var string $title   Titre de la playlist
+ * @var string $baseUrl Préfixe absolu du site, sans barre oblique finale
  */
 
 $document = new DOMDocument('1.0', 'utf-8');
@@ -35,12 +42,7 @@ foreach ($posts as $post) {
   $track = $document->createElement('track');
   $trackList->appendChild($track);
 
-  $location = sprintf(
-    '%s%s/tracks/%s',
-    $sf_request->getUriPrefix(),
-    $sf_request->getRelativeUrlRoot(),
-    rawurlencode($post->track_filename)
-  );
+  $location = sprintf('%s/tracks/%s', $baseUrl, rawurlencode($post->track_filename));
 
   // createTextNode échappe les valeurs : guillemets, esperluettes et chevrons
   // d'un titre ou d'un corps de post ne peuvent pas casser le document.

--- a/src/apps/frontend/modules/post/templates/listSuccess.xspf.php
+++ b/src/apps/frontend/modules/post/templates/listSuccess.xspf.php
@@ -14,4 +14,8 @@ if ($sf_request->getParameter('contributor')) {
   $title = 'Musique Approximative : Tous les morceaux';
 }
 
-include_partial('post/xspfPlaylist', array('posts' => $posts, 'title' => $title));
+include_partial('post/xspfPlaylist', array(
+  'posts' => $posts,
+  'title' => $title,
+  'baseUrl' => $sf_request->getUriPrefix() . $sf_request->getRelativeUrlRoot(),
+));

--- a/src/apps/frontend/modules/post/templates/showSuccess.xspf.php
+++ b/src/apps/frontend/modules/post/templates/showSuccess.xspf.php
@@ -8,4 +8,8 @@ $title = sprintf(
   $post->track_title
 );
 
-include_partial('post/xspfPlaylist', array('posts' => array($post), 'title' => $title));
+include_partial('post/xspfPlaylist', array(
+  'posts' => array($post),
+  'title' => $title,
+  'baseUrl' => $sf_request->getUriPrefix() . $sf_request->getRelativeUrlRoot(),
+));


### PR DESCRIPTION
Vérification après déploiement. **Une bonne nouvelle, une mauvaise, et une trouvaille** — la troisième ayant produit un changement à part, ajouté en fin de pull request.

---

# 1. Ma correction XSPF ne marchait pas

Déployée — `?kraftwerk` force son désastre, donc la #112, postérieure, est en ligne — et `?format=xspf` répondait toujours **500 avec un corps vide**.

## La cause

```php
function get_partial($templateName, $vars = []) {
    ...
    $view->setPartialVars(... $vars);   // ← seules les variables passées
    return $view->render();
}
```

**Un partiel symfony 1 est hermétique.** Son porteur d'attributs ne contient que ce qu'on lui passe : ni `$sf_request`, ni `$sf_data`, ni `$sf_context`. Le partiel appelait `$sf_request->getUriPrefix()` — méthode sur `null`, erreur fatale, 500 muet.

Corrigé en passant `baseUrl`, calculé par l'appelant. Le partiel a besoin d'un préfixe, pas d'un objet requête, et son contrat en devient explicite.

## Pourquoi mon banc d'essai ne l'a pas vu

Il déclarait `$sf_request` comme variable locale avant d'inclure le gabarit. **Il validait la logique du gabarit, jamais la portée que le framework lui accorde.** Un banc qui fournit ce que l'appelant réel ne fournit pas ne teste que lui-même.

Refait en reproduisant l'isolement : sept assertions vertes avec `baseUrl`, et l'échec attendu — `Undefined variable $baseUrl` — sans.

`DOMDocument` a été écarté **par mesure et non par supposition** : `/oembed?format=xml` répond 200 en production et construit sa réponse avec `SimpleXMLElement`.

---

# 2. Les désastres, eux, fonctionnent

Campagne complète contre la production.

**Les dix-neuf déclencheurs forcent leur désastre, sans exception.** Y compris `?splitouine_titles_matchduration`, le nom long qu'on avait hésité à raccourcir.

**Les quatre règles ressuscitées sont chargées** : `?spooky`, `?quickos` et `?quickos_noel` produisent le désastre `redirect`, et `desastres/splitouine` est injecté à chaque requête sur `/post/patric-catani-le-split` — sept mois après avoir été écrit.

**L'échéance de décembre est levée.** La tâche 4.4 de `reparer-imports-desastres` attendait Noël ; `?quickos` la remplace.

**Aucune régression** : sans paramètre, seul `splitouine` (`probability: 1`) apparaît, dix fois sur dix. Le témoin `danse` continue de se déclencher seul. Rien n'est injecté hors HTML, même avec un déclencheur.

Deux cases restent ouvertes à dessein : elles supposent de casser volontairement la configuration — un import fautif, une recette désactivée — ce qui n'a pas sa place sur un site en ligne.

---

# 3. Le cache gèle l'aléatoire

Trouvaille de la campagne, qui a produit son propre changement : **`preciser-aleatoire-des-desastres`**, ajouté ici faute d'une seconde branche disponible.

Sur `/post/eloi-soleil-mort`, dont le titre satisfait la règle `postillons_mort` à `probability: 0.7` :

| Requête | Déclenchements |
|---|---|
| URL nue, 20 fois | **0 / 20** |
| URL variée par un paramètre inerte, 20 fois | **11 / 20** |

À 0,7, obtenir 0 sur 20 a une probabilité de 3 × 10⁻¹¹. Le tirage est **figé par URL**. Ni le navigateur ni Cloudflare n'y sont pour quelque chose — `no-store, no-cache, must-revalidate` et `cf-cache-status: DYNAMIC`. C'est le cache de vues de Symfony, et `cache.yml` en donne la portée :

```yaml
default:
  enabled:     true
  with_layout: true
  lifetime:    86400
```

Toutes les actions, avec habillage, **vingt-quatre heures**. Un désastre tiré une fois est servi à tous les visiteurs de cette URL pendant une journée.

**Un désastre à `probability: 0.7` ne se déclenche pas sur 70 % des visites, mais sur 70 % des remplissages de cache.**

Le corpus affirmait que « deux consultations de la même page ne produisent pas nécessairement le même effet ». Elles produisent **toujours** le même. Le changement corrige l'exigence et en ajoute une sur la granularité : le hasard porte sur l'adresse et sur le moment, jamais sur le visiteur.

**Il décrit, il ne corrige pas.** Rétablir un aléa par visiteur supposerait de soustraire les désastres au cache — or un succès de cache court-circuite l'action entière, donc `apply_desastre()` n'est même pas rappelée. C'est une décision d'architecture, pas un réglage, et elle porterait sur les deux actions qui font l'essentiel du trafic. Le choix est réversible, et un changement ultérieur partirait d'un corpus exact.

---

## État

```
  appliquer-settings-yml-par-lapp   22/24
  generaliser-trigger-desastres     23/24
  preciser-aleatoire-des-desastres   7/10
  reparer-format-xspf               12/21
  reparer-fusion-automatique        16/17
  reparer-imports-desastres         20/21
  retirer-renovate                   8/13
  retirer-scan-trivy                 6/8
```

`openspec validate --all` : 14 items, 0 échec. La correction XSPF demande un nouveau déploiement pour être vérifiée.